### PR TITLE
Feature add edition mode

### DIFF
--- a/app/models/concerns/with_edition_mode.rb
+++ b/app/models/concerns/with_edition_mode.rb
@@ -3,7 +3,7 @@ module WithEditionMode
 
   attr_accessor :edition_mode
 
-  def editable!
+  def edit!
     self.edition_mode = true
   end
 

--- a/app/models/concerns/with_edition_mode.rb
+++ b/app/models/concerns/with_edition_mode.rb
@@ -1,0 +1,23 @@
+module WithEditionMode
+  extend ActiveSupport::Concern
+
+  attr_accessor :edition_mode
+
+  def editable!
+    self.edition_mode = true
+  end
+
+  module ClassMethods
+    def editable(*selectors)
+      selectors.each { |selector| editable_field selector }
+    end
+
+    private
+
+    def editable_field(selector)
+      patch selector do |*args, hyper|
+        edition_mode ? self[selector] : hyper.(*args)
+      end
+    end
+  end
+end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -8,7 +8,8 @@ class Exercise < ApplicationRecord
           WithLanguage,
           Assistable,
           WithRandomizations,
-          WithDiscussions
+          WithDiscussions,
+          WithEditionMode
 
   include Submittable,
           Questionable
@@ -25,6 +26,8 @@ class Exercise < ApplicationRecord
 
   randomize :description, :hint, :extra, :test, :default_content
   delegate :timed?, to: :navigable_parent
+
+  editable :description, :hint, :test, :default_content
 
   def console?
     queriable?

--- a/app/models/exercise/challenge.rb
+++ b/app/models/exercise/challenge.rb
@@ -16,6 +16,8 @@ class Challenge < Exercise
       .ensure_newline
   end
 
+  editable :extra
+
   private
 
   def defaults

--- a/app/models/exercise/problem.rb
+++ b/app/models/exercise/problem.rb
@@ -25,6 +25,8 @@ class Problem < QueriableChallenge
     own_expectations + guide_expectations
   end
 
+  editable :expectations
+
   def guide_expectations
     guide.expectations
   end

--- a/spec/models/with_edition_mode_spec.rb
+++ b/spec/models/with_edition_mode_spec.rb
@@ -2,18 +2,22 @@ require 'spec_helper'
 
 describe WithEditionMode do
 
-  let(:guide) { create :guide, extra: 'some guide extra code' }
-  let(:exercise) { create(:exercise, description: '$some_string', extra: 'some exercise extra code', guide: guide, randomizations: { some_string: { type: :one_of, value: %w(some string) } }) }
+  let(:guide) { create :guide, extra: 'some guide extra code', expectations: [{binding: 'bar', inspection: 'HasBinding'}] }
+  let(:exercise) { create :exercise, description: '$some_string', extra: 'some exercise extra code', guide: guide, randomizations: { some_string: { type: :one_of, value: %w(some string) } } }
+  let(:exercise_with_expectations) { create :exercise, guide: guide, expectations: [{binding: 'foo', inspection: 'HasBinding'}] }
 
   context 'with edition_mode off it works as usual' do
     it { expect(exercise.extra).to eq "some guide extra code\nsome exercise extra code\n" }
     it { expect(exercise.description).to eq 'some' }
+    it { expect(exercise_with_expectations.expectations).to eq [{'binding' => 'foo', 'inspection' => 'HasBinding'}, {'binding' => 'bar', 'inspection' => 'HasBinding'}] }
   end
 
   context 'with edition_mode on it simply returns the field as is' do
     before { exercise.edit! }
+    before { exercise_with_expectations.edit! }
 
     it { expect(exercise.extra).to eq 'some exercise extra code' }
     it { expect(exercise.description).to eq '$some_string'}
+    it { expect(exercise_with_expectations.expectations).to eq [{'binding' => 'foo', 'inspection' => 'HasBinding'}] }
   end
 end

--- a/spec/models/with_edition_mode_spec.rb
+++ b/spec/models/with_edition_mode_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe WithEditionMode do
+
+  let(:guide) { create :guide, extra: 'some guide extra code' }
+  let(:exercise) { create(:exercise, description: '$some_string', extra: 'some exercise extra code', guide: guide, randomizations: { some_string: { type: :one_of, value: %w(some string) } }) }
+
+  context 'with edition_mode off it works as usual' do
+    it { expect(exercise.extra).to eq "some guide extra code\nsome exercise extra code\n" }
+    it { expect(exercise.description).to eq 'some' }
+  end
+
+  context 'with edition_mode on it simply returns the field as is' do
+    before { exercise.editable! }
+
+    it { expect(exercise.extra).to eq 'some exercise extra code' }
+    it { expect(exercise.description).to eq '$some_string'}
+  end
+end

--- a/spec/models/with_edition_mode_spec.rb
+++ b/spec/models/with_edition_mode_spec.rb
@@ -11,7 +11,7 @@ describe WithEditionMode do
   end
 
   context 'with edition_mode on it simply returns the field as is' do
-    before { exercise.editable! }
+    before { exercise.edit! }
 
     it { expect(exercise.extra).to eq 'some exercise extra code' }
     it { expect(exercise.description).to eq '$some_string'}


### PR DESCRIPTION
This PR is to address some issues we're having now that we're taking common models to mumuki-domain.

Some of these issues are:
1. When importing guides from bibliotheca in laboratory, the exercises' extra has the guide's extra already embedded 
1. Again, when importing guides, if an exercise has randomizations, the imported contents already have an interpolated value, instead of just keeping the interpolation.
1. and more... (maybe)

These are all happening because it's expected logic in laboratory, but not in bibliotheca.

The idea is for this to be only a temporary fix, so I tried to make it as unobtrusive as possible.

Ideally, we should remove this special logic from exercise in laboratory, and move it to assignment instead, but this would probably be a non backwards compatible change.