### PR TITLE
Issue resource h calculated attributes

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -106,10 +106,17 @@ class Exercise < ApplicationRecord
 
   def to_resource_h
     language_resource_h = language.to_embedded_resource_h if language != guide.language
-    as_json(only: %i(name layout editor description corollary teacher_info hint test manual_evaluation locale extra
-                     choices expectations assistance_rules randomizations tag_list extra_visible goal default_content
+    as_json(only: %i(name layout editor corollary teacher_info manual_evaluation locale
+                     choices assistance_rules randomizations tag_list extra_visible goal
                      free_form_editor_source initial_state final_state))
       .merge(id: bibliotheca_id, language: language_resource_h, type: type.underscore)
+      .merge(
+        default_content: self[:default_content],
+        description: self[:description],
+        expectations: self[:expectations],
+        extra: self[:extra],
+        hint: self[:hint],
+        test: self[:test])
       .symbolize_keys
       .compact
   end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,4 +1,6 @@
 class Exercise < ApplicationRecord
+  RANDOMIZED_FIELDS = [:default_content, :description, :extra, :hint, :test]
+
   include WithDescription
   include WithLocale
   include WithNumber,
@@ -23,7 +25,7 @@ class Exercise < ApplicationRecord
   validates_presence_of :submissions_count,
                         :guide, :bibliotheca_id
 
-  randomize :description, :hint, :extra, :test, :default_content
+  randomize(*RANDOMIZED_FIELDS)
   delegate :timed?, to: :navigable_parent
 
   def console?
@@ -110,13 +112,8 @@ class Exercise < ApplicationRecord
                      choices assistance_rules randomizations tag_list extra_visible goal
                      free_form_editor_source initial_state final_state))
       .merge(id: bibliotheca_id, language: language_resource_h, type: type.underscore)
-      .merge(
-        default_content: self[:default_content],
-        description: self[:description],
-        expectations: self[:expectations],
-        extra: self[:extra],
-        hint: self[:hint],
-        test: self[:test])
+      .merge(expectations: own_expectations)
+      .merge(RANDOMIZED_FIELDS.map { |it| [it, self[it]] }.to_h)
       .symbolize_keys
       .compact
   end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -23,7 +23,7 @@ class Exercise < ApplicationRecord
   validates_presence_of :submissions_count,
                         :guide, :bibliotheca_id
 
-  randomize :description, :hint, :extra, :test
+  randomize :description, :hint, :extra, :test, :default_content
   delegate :timed?, to: :navigable_parent
 
   def console?
@@ -170,12 +170,6 @@ class Exercise < ApplicationRecord
   def inspection_keywords
     {}
   end
-
-  def default_content
-    self[:default_content] || ''
-  end
-
-  randomize :default_content
 
   # Submits the user solution
   # only if the corresponding assignment has attemps left

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -23,7 +23,7 @@ class Exercise < ApplicationRecord
   validates_presence_of :submissions_count,
                         :guide, :bibliotheca_id
 
-  randomize :description, :hint, :extra, :test, :default_content
+  randomize :description, :hint, :extra, :test
   delegate :timed?, to: :navigable_parent
 
   def console?
@@ -174,6 +174,8 @@ class Exercise < ApplicationRecord
   def default_content
     self[:default_content] || ''
   end
+
+  randomize :default_content
 
   # Submits the user solution
   # only if the corresponding assignment has attemps left

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -75,6 +75,7 @@ class Language < ApplicationRecord
 
   # TODO we should use Mumukit::Directives::Pipeline
   def interpolate(interpolee, *interpolations)
+    interpolee = interpolee || ''
     interpolations.inject(interpolee) { |content, interpolation| directives_interpolations.interpolate(content, interpolation).first }
   end
 

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -48,8 +48,7 @@ describe Guide do
     it { expect(exercise.hint).to eq "try some" }
     it { expect(exercise.test).to eq 'describe "some" do pending end' }
 
-    it { expect(exercise.to_resource_h).to json_eq(
-            {
+    it { expect(exercise.to_resource_h).to json_eq({
               default_content: 'x = "$randomizedWord" /*...previousSolution...*/',
               description: 'works with $randomizedWord',
               expectations: [],
@@ -57,7 +56,7 @@ describe Guide do
               hint: 'try $randomizedWord',
               test: 'describe "$randomizedWord" do pending end'
             },
-            only: [:default_content, :description, :expectations, :extra, :hint, :test]) }
+            only: Exercise::RANDOMIZED_FIELDS) }
   end
 
   describe '#fork!' do

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -24,6 +24,30 @@ describe Guide do
     end
   end
 
+  describe '#to_resource_h' do
+    let!(:guide) {
+      create(:guide,
+        extra: 'guide extra',
+        expectations: [{binding: 'guide', inspection: 'Uses:expectations'}],
+        exercises: [exercise])}
+    let(:exercise) {
+      build(:exercise,
+        extra: 'exercise extra',
+        description: 'works with $randomizedWord',
+        randomizations: {
+          randomizedWord: { type: :one_of, value: %w(some) }
+        })}
+
+    it { expect(exercise.expectations).to eq guide.expectations }
+    it { expect(exercise.extra).to eq "guide extra\nexercise extra\n" }
+    it { expect(exercise.description).to eq "works with some" }
+    it { expect(exercise.to_resource_h).to json_eq(
+            { extra: 'exercise extra',
+              description: 'works with $randomizedWord',
+              expectations: [] },
+            only: [:extra, :description, :expectations]) }
+  end
+
   describe '#fork!' do
     let(:syncer) { double(:syncer) }
     let!(:guide_from) { create :guide, slug: 'foo/bar' }

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -24,7 +24,7 @@ describe Guide do
     end
   end
 
-  describe '#to_resource_h' do
+  describe 'customizations' do
     let!(:guide) {
       create(:guide,
         extra: 'guide extra',
@@ -32,20 +32,32 @@ describe Guide do
         exercises: [exercise])}
     let(:exercise) {
       build(:exercise,
-        extra: 'exercise extra',
+        default_content: 'x = "$randomizedWord" /*...previousSolution...*/',
         description: 'works with $randomizedWord',
+        extra: 'exercise extra',
+        hint: 'try $randomizedWord',
+        test: 'describe "$randomizedWord" do pending end',
         randomizations: {
           randomizedWord: { type: :one_of, value: %w(some) }
         })}
 
+    it { expect(exercise.default_content).to eq 'x = "some" /*...previousSolution...*/' }
+    it { expect(exercise.description).to eq "works with some" }
     it { expect(exercise.expectations).to eq guide.expectations }
     it { expect(exercise.extra).to eq "guide extra\nexercise extra\n" }
-    it { expect(exercise.description).to eq "works with some" }
+    it { expect(exercise.hint).to eq "try some" }
+    it { expect(exercise.test).to eq 'describe "some" do pending end' }
+
     it { expect(exercise.to_resource_h).to json_eq(
-            { extra: 'exercise extra',
+            {
+              default_content: 'x = "$randomizedWord" /*...previousSolution...*/',
               description: 'works with $randomizedWord',
-              expectations: [] },
-            only: [:extra, :description, :expectations]) }
+              expectations: [],
+              extra: 'exercise extra',
+              hint: 'try $randomizedWord',
+              test: 'describe "$randomizedWord" do pending end'
+            },
+            only: [:default_content, :description, :expectations, :extra, :hint, :test]) }
   end
 
   describe '#fork!' do


### PR DESCRIPTION
This fix address the same issue reported by @julian-berbel in #8 , but without introducing edit mode and without doing an assignments refactor as in #10 . However, I would be nice to do something like that on the future. 

The good thing is that it is a backward compatible change. Since I am basing this PR on `v6.2.0` and not `v6.3.0`, we could tag it as a micro versions of 6.2 series. 



