### PR TITLE
Fix in path bug

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -48,6 +48,7 @@ class Book < Content
   end
 
   def index_usage!(organization)
+    organization.index_usage_of! self, self
     [chapters, complements].flatten.each { |item| item.index_usage! organization }
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -138,7 +138,7 @@ class Organization < ApplicationRecord
     #
     # See `Organization#in_path?`
     def in_path(content)
-      content.usages.map(&:organization).uniq
+      content.usages.map &:organization
     end
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -133,12 +133,12 @@ class Organization < ApplicationRecord
     # Answers organizations that have the given item
     # in their paths.
     #
+    # Warning: unlike `in_path?`, this method does only work with
+    # content - child - items instead of both kind of items - content and content containers.
+    #
     # See `Organization#in_path?`
-    def in_path(item)
-      joins(:usages)
-        .select('organizations.*, usages.item_id')
-        .where('usages.item_id = ?', item.id)
-        .distinct()
+    def in_path(content)
+      content.usages.map(&:organization).uniq
     end
   end
 end

--- a/spec/models/usage_spec.rb
+++ b/spec/models/usage_spec.rb
@@ -46,7 +46,7 @@ describe Usage do
     it { expect(oop.usage_in_organization.number).to eq 3 }
     it { expect(logic_programming.usage_in_organization.number).to eq 4 }
 
-    it { expect(Usage.in_organization.count).to eq 4  }
+    it { expect(Usage.in_organization.count).to eq 5  }
 
   end
 
@@ -72,6 +72,6 @@ describe Usage do
     it { expect(logic_programming.usage_in_organization.number).to eq 2 }
     it { expect(oop.usage_in_organization.number).to eq 3 }
 
-    it { expect(Usage.in_organization.count).to eq 3  }
+    it { expect(Usage.in_organization.count).to eq 4  }
   end
 end


### PR DESCRIPTION
Currently, it was mostly working for guides, but:

* It answered wrong results when there was more than one item of different types with the same id 
* It was completely broken for book usages - it only worked by chance, hidden by the aforementioned bug 