### PR TITLE
Refactoring transparent navigation API

### DIFF
--- a/app/models/concerns/with_slug.rb
+++ b/app/models/concerns/with_slug.rb
@@ -8,7 +8,7 @@ module WithSlug
     before_create :normalize_slug!
   end
 
-  def transparent_parms
+  def transparent_params
     org, repo = slug.split('/')
     {organization: org, repository: repo}
   end

--- a/app/models/concerns/with_slug.rb
+++ b/app/models/concerns/with_slug.rb
@@ -8,9 +8,13 @@ module WithSlug
     before_create :normalize_slug!
   end
 
-  def slug_parts
+  def transparent_parms
     org, repo = slug.split('/')
     {organization: org, repository: repo}
+  end
+
+  def transparent_id
+    slug
   end
 
   def normalize_slug!
@@ -40,7 +44,7 @@ module WithSlug
       all.select { |it| !it.private? || permissions&.writer?(it.slug) }
     end
 
-    def by_slug_parts!(args)
+    def find_transparently!(args)
       find_by!(slug: "#{args[:organization]}/#{args[:repository]}")
     end
 

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -68,8 +68,8 @@ class Exercise < ApplicationRecord
     "#{guide.transparent_id}/#{bibliotheca_id}"
   end
 
-  def transparent_parms
-    guide.transparent_parms.merge(bibliotheca_id: bibliotheca_id)
+  def transparent_params
+    guide.transparent_params.merge(bibliotheca_id: bibliotheca_id)
   end
 
   def friendly

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -64,12 +64,12 @@ class Exercise < ApplicationRecord
     [language&.name, *tag_list].compact
   end
 
-  def slug
-    "#{guide.slug}/#{bibliotheca_id}"
+  def transparent_id
+    "#{guide.transparent_id}/#{bibliotheca_id}"
   end
 
-  def slug_parts
-    guide.slug_parts.merge(bibliotheca_id: bibliotheca_id)
+  def transparent_parms
+    guide.transparent_parms.merge(bibliotheca_id: bibliotheca_id)
   end
 
   def friendly
@@ -191,6 +191,10 @@ class Exercise < ApplicationRecord
       .directives_sections
       .split_sections(current_content)
       .map { |name, content| Mumuki::Domain::File.new name, content }
+  end
+
+  def self.find_transparently!(params)
+    Guide.find_transparently!(params).exercises.find_by!(bibliotheca_id: params[:bibliotheca_id])
   end
 
   private

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -34,7 +34,7 @@ describe Exercise do
     let(:params) { { organization: 'foo', repository: 'bar', bibliotheca_id: 4 } }
 
     it { expect(exercise.transparent_id).to eq 'foo/bar/4' }
-    it { expect(exercise.transparent_parms).to eq params }
+    it { expect(exercise.transparent_params).to eq params }
     it { expect(Exercise.find_transparently!(params)).to eq exercise }
   end
 

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -28,10 +28,14 @@ describe Exercise do
     end
   end
 
-  describe '#slug' do
+  describe 'transparent navigation api' do
     let(:guide) { create(:guide, slug: 'foo/bar') }
-    let(:exercise) { create(:exercise, guide: guide, bibliotheca_id: 4) }
-    it { expect(exercise.slug).to eq 'foo/bar/4' }
+    let!(:exercise) { create(:exercise, guide: guide, bibliotheca_id: 4) }
+    let(:params) { { organization: 'foo', repository: 'bar', bibliotheca_id: 4 } }
+
+    it { expect(exercise.transparent_id).to eq 'foo/bar/4' }
+    it { expect(exercise.transparent_parms).to eq params }
+    it { expect(Exercise.find_transparently!(params)).to eq exercise }
   end
 
   describe '#new_solution' do

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -125,6 +125,15 @@ describe Guide do
     end
   end
 
+  describe 'transparent navigation api' do
+    let!(:guide) { create(:guide, slug: 'foo/bar') }
+    let(:params) { { organization: 'foo', repository: 'bar' } }
+
+    it { expect(guide.transparent_id).to eq 'foo/bar' }
+    it { expect(guide.transparent_parms).to eq params }
+    it { expect(Guide.find_transparently!(params)).to eq guide }
+  end
+
   describe '#to_markdownified_resource_h' do
     subject { guide.to_markdownified_resource_h }
     context 'description' do

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -130,7 +130,7 @@ describe Guide do
     let(:params) { { organization: 'foo', repository: 'bar' } }
 
     it { expect(guide.transparent_id).to eq 'foo/bar' }
-    it { expect(guide.transparent_parms).to eq params }
+    it { expect(guide.transparent_params).to eq params }
     it { expect(Guide.find_transparently!(params)).to eq guide }
   end
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1,23 +1,13 @@
 require 'spec_helper'
 
 describe Topic do
-  let!(:haskell) { create(:haskell) }
-  let!(:gobstones) { create(:gobstones) }
+  describe 'transparent navigation api' do
+    let!(:topic) { create(:topic, slug: 'foo/bar') }
+    let(:params) { { organization: 'foo', repository: 'bar' } }
 
-  let!(:lesson_1) { create(:lesson, name: 'l1') }
-  let(:guide_1) { lesson_1.guide }
-
-  let!(:lesson_2) { create(:lesson, name: 'l2') }
-
-  let!(:guide_2) { create(:guide, name: 'g2') }
-  let!(:guide_3) { create(:guide, name: 'g3') }
-
-  let(:topic_resource_h) do
-    {name: 'sample topic',
-     description: 'topic description',
-     slug: 'mumuki/mumuki-sample-topic',
-     locale: 'en',
-     lessons: [guide_2, guide_1, guide_3].map(&:slug)}
+    it { expect(topic.transparent_id).to eq 'foo/bar' }
+    it { expect(topic.transparent_parms).to eq params }
+    it { expect(Topic.find_transparently!(params)).to eq topic }
   end
 
   describe 'slug normalization' do
@@ -27,6 +17,25 @@ describe Topic do
   end
 
   describe '#import_from_resource_h!' do
+    let!(:haskell) { create(:haskell) }
+    let!(:gobstones) { create(:gobstones) }
+
+    let!(:lesson_1) { create(:lesson, name: 'l1') }
+    let(:guide_1) { lesson_1.guide }
+
+    let!(:lesson_2) { create(:lesson, name: 'l2') }
+
+    let!(:guide_2) { create(:guide, name: 'g2') }
+    let!(:guide_3) { create(:guide, name: 'g3') }
+
+    let(:topic_resource_h) do
+      {name: 'sample topic',
+       description: 'topic description',
+       slug: 'mumuki/mumuki-sample-topic',
+       locale: 'en',
+       lessons: [guide_2, guide_1, guide_3].map(&:slug)}
+    end
+
     context 'when guide is empty' do
       let(:topic) { create(:topic, lessons: [lesson_1, lesson_2]) }
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -6,7 +6,7 @@ describe Topic do
     let(:params) { { organization: 'foo', repository: 'bar' } }
 
     it { expect(topic.transparent_id).to eq 'foo/bar' }
-    it { expect(topic.transparent_parms).to eq params }
+    it { expect(topic.transparent_params).to eq params }
     it { expect(Topic.find_transparently!(params)).to eq topic }
   end
 


### PR DESCRIPTION
This refactor introduces several changes:

* a more consistent api naming for the `slug_parts`, `slug` and `by_slug_parts` methods
* now exercises can be found by transparent params, too
* exercises do not expose a slug method anymore, which is important since after https://github.com/mumuki/mumukit-auth/commit/69077a185552300d60c9b22318ab9240ccf1e064, mumukit-auth will validate slugs have only one `/`