### PR TITLE
Fixing error and raising GoneError instead

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -41,7 +41,7 @@ class Invitation < ApplicationRecord
   end
 
   def unexpired
-    raise RecordNotFound, "This invitation has already expired" if expired?
+    raise Mumuki::Domain::GoneError, "This invitation has already expired" if expired?
     self
   end
 

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,10 +1,25 @@
+require 'spec_helper'
+
 describe Invitation, organization_workspace: :test do
+  let(:course) { create :course, slug: 'test/bar' }
+
   describe '.import_from_resource_h!' do
-    let!(:course) { create :course, slug: 'test/bar' }
-    let(:invitation) { Invitation.import_from_resource_h! code: 'eZNvuQ', course: 'test/bar', expiration_date: 2.days.since }
+    let(:invitation) { Invitation.import_from_resource_h! code: 'eZNvuQ', course: course.slug, expiration_date: 2.days.since }
 
     it { expect(invitation).to_not be nil }
     it { expect(invitation.code).to eq 'eZNvuQ' }
     it { expect(invitation.course_slug).to eq 'test/bar' }
+  end
+
+  describe '#unexpired' do
+    let(:invitation) { create(:invitation, expiration_date: expiration, course: course) }
+    context 'when expired' do
+      let(:expiration) { 5.minutes.ago }
+      it { expect { invitation.unexpired }.to raise_error Mumuki::Domain::GoneError }
+    end
+    context 'when not expired' do
+      let(:expiration) { 5.minutes.since }
+      it { expect(invitation.unexpired).to eq invitation }
+    end
   end
 end


### PR DESCRIPTION
When user accesses an expired invitation, it raise a 500, since the exception namespace for `NotFoundError` was missing. 

However raising a `GoneError` has a lot more sense here, so I also changed that 