### PR TITLE
Automatically subscribing users who comment a discussion

### DIFF
--- a/app/models/concerns/with_discussion_creation/subscription.rb
+++ b/app/models/concerns/with_discussion_creation/subscription.rb
@@ -3,7 +3,7 @@ module WithDiscussionCreation::Subscription
 
   included do
     has_many :subscriptions
-    has_many :watched_discussions, through: :subscriptions, source: :discussion
+    has_many :watched_discussions, -> { order(created_at: :desc) }, through: :subscriptions, source: :discussion
     organic_on :watched_discussions
   end
 
@@ -16,7 +16,7 @@ module WithDiscussionCreation::Subscription
   end
 
   def subscribe_to!(discussion)
-    watched_discussions << discussion
+    watched_discussions << discussion unless subscribed_to? discussion
   end
 
   def unsubscribe_to!(discussion)

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -84,6 +84,7 @@ class Discussion < ApplicationRecord
   def submit_message!(message, user)
     message.merge!(sender: user.uid)
     messages.create(message)
+    user.subscribe_to! self
     unread_subscriptions(user)
   end
 

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -54,6 +54,7 @@ describe Discussion, organization_workspace: :test do
       it { expect(discussion.reachable_statuses_for initiator).to eq [:pending_review] }
       it { expect(discussion.reachable_statuses_for moderator).to eq [:closed, :solved] }
       it { expect(discussion.reachable_statuses_for student).to eq [] }
+      it { expect(student.subscribed_to? discussion).to be true }
 
       describe 'gets updated to pending_review by initiator' do
         before { discussion.update_status!(:pending_review, initiator) }


### PR DESCRIPTION
Also, I'm ordering the watched_discussions from newest to latest

Feature requested by @rgonzalezt