### PR TITLE
Skip sanitization on description

### DIFF
--- a/app/models/concerns/with_description.rb
+++ b/app/models/concerns/with_description.rb
@@ -2,7 +2,7 @@ module WithDescription
   extend ActiveSupport::Concern
 
   included do
-    markdown_on :description, :description_teaser
+    markdown_on :description, :description_teaser, skip_sanitization: true
     validates_presence_of :description
   end
 

--- a/mumuki-domain.gemspec
+++ b/mumuki-domain.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mumukit-auth', '~> 7.6'
   s.add_dependency 'mumukit-assistant', '~> 0.1'
   s.add_dependency 'mumukit-bridge', '~> 3.8'
-  s.add_dependency 'mumukit-content-type', '~> 1.6'
+  s.add_dependency 'mumukit-content-type', '~> 1.7'
   s.add_dependency 'mumukit-core', '~> 1.13'
   s.add_dependency 'mumukit-directives', '~> 0.5'
   s.add_dependency 'mumukit-inspection', '~> 3.6'


### PR DESCRIPTION
Requires mumuki/mumukit-content-type#11.

~I'm not too sure about this way of writing it... I don't like that I have to explicitly pass `options: {...}` and can't just pass `skip_sanitization: true`.~

~What do you think @flbulgarelli ?~

Fixed with ruby's double splat for keyword arguments. 😍 oh ruby....