### PR TITLE
Knowing in which organization an assignment is submitted

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -12,7 +12,7 @@ class Assignment < ApplicationRecord
            primary_key: :submission_id,
            dependent: :destroy
 
-  belongs_to :organization, default: -> { Organization.current }
+  belongs_to :organization
   belongs_to :submitter, class_name: 'User'
 
   validates_presence_of :exercise, :submitter

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -12,6 +12,7 @@ class Assignment < ApplicationRecord
            primary_key: :submission_id,
            dependent: :destroy
 
+  belongs_to :organization, default: -> { Organization.current }
   belongs_to :submitter, class_name: 'User'
 
   validates_presence_of :exercise, :submitter
@@ -126,7 +127,7 @@ class Assignment < ApplicationRecord
   end
 
   def to_resource_h
-    as_json(except: [:exercise_id, :submission_id, :id, :submitter_id, :solution, :created_at, :updated_at, :submission_status],
+    as_json(except: [:exercise_id, :submission_id, :organization_id, :id, :submitter_id, :solution, :created_at, :updated_at, :submission_status],
               include: {
                 guide: {
                   only: [:slug, :name],

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -190,6 +190,11 @@ class Assignment < ApplicationRecord
     exercise.files_for(current_content)
   end
 
+  def save!(*)
+    self.organization = Organization.current
+    super
+  end
+
   private
 
   def update_submissions_count!

--- a/app/models/concerns/with_assignments.rb
+++ b/app/models/concerns/with_assignments.rb
@@ -18,7 +18,7 @@ module WithAssignments
     messages_for(user).present?
   end
 
-  def find_assignment_for(user, organization)
+  def find_assignment_for(user, _organization)
     assignments.find_by(submitter: user)
   end
 

--- a/app/models/concerns/with_assignments.rb
+++ b/app/models/concerns/with_assignments.rb
@@ -19,7 +19,7 @@ module WithAssignments
   end
 
   def find_assignment_for(user, organization)
-    assignments.find_by(submitter: user, organization: organization)
+    assignments.find_by(submitter: user)
   end
 
   def status_for(user)

--- a/app/models/concerns/with_assignments.rb
+++ b/app/models/concerns/with_assignments.rb
@@ -18,15 +18,15 @@ module WithAssignments
     messages_for(user).present?
   end
 
-  def find_assignment_for(user)
-    assignments.find_by(submitter: user)
+  def find_assignment_for(user, organization)
+    assignments.find_by(submitter: user, organization: organization)
   end
 
   def status_for(user)
     assignment_for(user).status if user
   end
 
-  def assignment_for(user)
-    find_assignment_for(user) || user.assignments.build(exercise: self)
+  def assignment_for(user, organization: Organization.current)
+    find_assignment_for(user, organization) || user.assignments.build(exercise: self, organization: organization)
   end
 end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -14,10 +14,10 @@ class Guide < Content
 
   enum type: [:learning, :practice]
 
-  def clear_progress!(user)
+  def clear_progress!(user, organization)
     transaction do
       exercises.each do |exercise|
-        exercise.find_assignment_for(user)&.destroy!
+        exercise.find_assignment_for(user, organization)&.destroy!
       end
     end
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -18,7 +18,7 @@ class Organization < ApplicationRecord
   validates_presence_of :contact_email, :locale
   validates :name, uniqueness: true,
                    presence: true,
-                   format: { with: Mumuki::Domain::Helpers::Organization.anchored_valid_name_regex }
+                   format: { with: Mumukit::Platform::Organization.anchored_valid_name_regex }
   validates :locale, inclusion: { in: Mumukit::Platform::Locale.supported }
 
   after_create :reindex_usages!

--- a/db/migrate/20190530173142_add_organization_to_assignment.rb
+++ b/db/migrate/20190530173142_add_organization_to_assignment.rb
@@ -1,0 +1,5 @@
+class AddOrganizationToAssignment < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :assignments, :organization, index: true
+  end
+end

--- a/lib/mumuki/domain/factories/assignments_factory.rb
+++ b/lib/mumuki/domain/factories/assignments_factory.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     status { :pending }
     exercise
     submitter { create(:user) }
+    organization { Organization.current }
   end
 end

--- a/lib/mumuki/domain/factories/organization_factory.rb
+++ b/lib/mumuki/domain/factories/organization_factory.rb
@@ -9,10 +9,8 @@ FactoryBot.define do
     book
   end
 
-  factory :base, parent: :organization do
-    public { true }
-    name { 'base' }
-    login_methods { Mumukit::Login::Settings.login_methods }
+  factory :private_organization, parent: :organization do
+    name { 'the-private-org' }
   end
 
   factory :public_organization, parent: :organization do
@@ -21,7 +19,20 @@ FactoryBot.define do
     login_methods { Mumukit::Login::Settings.login_methods }
   end
 
-  factory :private_organization, parent: :organization do
-    name { 'the-private-org' }
+  factory :base, parent: :public_organization do
+    name { 'base' }
+  end
+
+  factory :test_organization, parent: :public_organization do
+    name { 'test' }
+    book { create(:book, name: 'test', slug: 'mumuki/mumuki-the-book') }
+  end
+
+  factory :another_test_organization, parent: :test_organization, traits: [:skip_unique_name_validation] do
+    book { create(:book, name: 'another-test', slug: 'mumuki/mumuki-another-book') }
+  end
+
+  trait :skip_unique_name_validation do
+    to_create { |instance| instance.save(validate: false) }
   end
 end

--- a/lib/mumuki/domain/helpers/organization.rb
+++ b/lib/mumuki/domain/helpers/organization.rb
@@ -54,20 +54,6 @@ module Mumuki::Domain::Helpers::Organization
     name
   end
 
-  ## Name validation
-
-  def self.valid_name?(name)
-    !!(name =~ anchored_valid_name_regex)
-  end
-
-  def self.anchored_valid_name_regex
-    /\A#{valid_name_regex}\z/
-  end
-
-  def self.valid_name_regex
-    /([-a-z0-9_]+(\.[-a-z0-9_]+)*)?/
-  end
-
   ## Resource Hash
 
   module ClassMethods

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190702003600) do
+ActiveRecord::Schema.define(version: 20190702182407) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,7 +41,9 @@ ActiveRecord::Schema.define(version: 20190702003600) do
     t.text "query_results"
     t.text "manual_evaluation_comment"
     t.integer "attemps_count", default: 0
+    t.bigint "organization_id"
     t.index ["exercise_id"], name: "index_assignments_on_exercise_id"
+    t.index ["organization_id"], name: "index_assignments_on_organization_id"
     t.index ["submission_id"], name: "index_assignments_on_submission_id"
     t.index ["submitter_id"], name: "index_assignments_on_submitter_id"
   end

--- a/spec/lib/organization_helpers_spec.rb
+++ b/spec/lib/organization_helpers_spec.rb
@@ -216,22 +216,7 @@ describe Mumukit::Platform::Organization do
       } }
       it { expect(organization.to_resource_h).to json_eq resource_h }
     end
-
-    describe '#valid_name?' do
-      def valid_name?(name)
-        Mumuki::Domain::Helpers::Organization.valid_name? name
-      end
-
-      it { expect(valid_name? 'foo').to be true }
-      it { expect(valid_name? 'a.name').to be true }
-      it { expect(valid_name? 'a.name.with.subdomains').to be true }
-      it { expect(valid_name? '.a.name.that.starts.with.period').to be false }
-      it { expect(valid_name? 'a.name.that.ends.with.period.').to be false }
-      it { expect(valid_name? 'a.name.that..has.two.periods.in.a.row').to be false }
-      it { expect(valid_name? 'a.name.with.Uppercases').to be false }
-      it { expect(valid_name? 'A random name').to be false }
-    end
-
+    
     describe '#as_json' do
       context 'when settings has unsupported attributes' do
         before { organization.settings.instance_variable_set :@saraza, 5 }

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -156,10 +156,10 @@ describe Assignment, organization_workspace: :test do
     let(:exercise) { create(:exercise) }
     let(:user) { create(:user) }
 
-    context "when solution is submitted" do
+    context 'when solution is submitted' do
       before { exercise.submit_solution!(user, content: 'foo') }
 
-      it "should persist what organization it was submitted in" do
+      it 'should persist what organization it was submitted in' do
         expect(exercise.assignment_for(user).organization).to eq Organization.current
       end
     end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -60,6 +60,7 @@ describe Assignment, organization_workspace: :test do
     it { expect(passed_submission_with_visible_output_language.results_visible?).to be true }
     it { expect(manual_evaluation_pending_submission.results_visible?).to be false }
   end
+
   describe '#expectation_results_visible?' do
     let(:haskell) { create(:language, visible_success_output: true) }
     let(:exercise) { create(:exercise) }
@@ -73,6 +74,7 @@ describe Assignment, organization_workspace: :test do
       it { expect(errored_submission.expectation_results_visible?).to be true }
     end
   end
+
   describe '#showable_results_visible?' do
     let(:failed_submission) { create(:assignment, exercise: problem, status: :failed, expectation_results: [{binding: "foo", inspection: "HasBinding", result: :failed},
                                                                                                             {binding: "bar", inspection: "HasBinding", result: :failed}]) }
@@ -87,6 +89,7 @@ describe Assignment, organization_workspace: :test do
       it { expect(failed_submission.visible_expectation_results.size).to eq 1 }
     end
   end
+
   describe '#run_update!' do
     let(:assignment) { create(:assignment) }
     context 'when run passes unstructured' do
@@ -147,6 +150,19 @@ describe Assignment, organization_workspace: :test do
     end
 
     it { expect(exercise.reload.submissions_count).to eq(3) }
+  end
+
+  describe 'organization' do
+    let(:exercise) { create(:exercise) }
+    let(:user) { create(:user) }
+
+    context "when solution is submitted" do
+      before { exercise.submit_solution!(user, content: 'foo') }
+
+      it "should persist what organization it was submitted in" do
+        expect(exercise.assignment_for(user).organization).to eq Organization.current
+      end
+    end
   end
 
   describe '#submission_id' do

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -161,12 +161,21 @@ describe Exercise do
   end
 
   describe '#submit_solution!', organization_workspace: :test do
-    context 'when user did a submission' do
-      before { exercise.submit_solution!(user) }
-      it { expect(exercise.find_assignment_for(user, Organization.current)).to be_present }
+    let(:test_organization) { Organization.current }
+    let(:another_organization) { create(:public_organization) }
+
+    context 'when user does no submission' do
+      it 'should not find a submission' do
+        expect(exercise.find_assignment_for(user, test_organization)).to be_blank
+      end
     end
-    context 'when user did no submission' do
-      it { expect(exercise.find_assignment_for(user, Organization.current)).to be_blank }
+
+    context 'when user does a submission in an organization' do
+      before { exercise.submit_solution!(user) }
+
+      it 'should find a submission for that user and organization' do
+        expect(exercise.find_assignment_for(user, test_organization)).to be_present
+      end
     end
   end
 
@@ -504,10 +513,10 @@ describe Exercise do
     end
   end
 
-  describe '#files_for', organization_workspace: :test do
+  describe '#files_for' do
     before { create(:language, extension: 'js', highlight_mode: 'javascript') }
     let(:current_content) { "/*<index.html#*/a html content/*#index.html>*/\n/*<a_file.js#*/a js content/*#a_file.js>*/" }
-    let(:assignment) { build(:assignment, exercise: exercise, solution: current_content) }
+    let(:assignment) { build(:assignment, exercise: exercise, solution: current_content, organization: create(:test_organization)) }
     let(:files) { exercise.files_for(current_content) }
 
     it { expect(files.count).to eq 2 }

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -504,7 +504,7 @@ describe Exercise do
     end
   end
 
-  describe '#files_for' do
+  describe '#files_for', organization_workspace: :test do
     before { create(:language, extension: 'js', highlight_mode: 'javascript') }
     let(:current_content) { "/*<index.html#*/a html content/*#index.html>*/\n/*<a_file.js#*/a js content/*#a_file.js>*/" }
     let(:assignment) { build(:assignment, exercise: exercise, solution: current_content) }

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -163,10 +163,10 @@ describe Exercise do
   describe '#submit_solution!', organization_workspace: :test do
     context 'when user did a submission' do
       before { exercise.submit_solution!(user) }
-      it { expect(exercise.find_assignment_for(user)).to be_present }
+      it { expect(exercise.find_assignment_for(user, Organization.current)).to be_present }
     end
     context 'when user did no submission' do
-      it { expect(exercise.find_assignment_for(user)).to be_blank }
+      it { expect(exercise.find_assignment_for(user, Organization.current)).to be_blank }
     end
   end
 

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -77,7 +77,8 @@ describe Exercise do
       it { expect(exercise_with_guide.next_for(user)).to eq alternative_exercise }
     end
 
-    context 'when exercise belongs to a guide with two exercises and alternative exercise has being solved' do
+    context 'when exercise belongs to a guide with two exercises and alternative exercise has been solved',
+            organization_workspace: :test do
       let(:exercise_with_guide) { create(:exercise, guide: guide) }
       let!(:alternative_exercise) { create(:exercise, guide: guide) }
       let(:guide) { create(:guide) }
@@ -87,7 +88,8 @@ describe Exercise do
       it { expect(exercise_with_guide.next_for(user)).to be nil }
     end
 
-    context 'when exercise belongs to a guide with two exercises and alternative exercise has being submitted but not solved' do
+    context 'when exercise belongs to a guide with two exercises and alternative exercise has been submitted but not solved',
+            organization_workspace: :test do
       let!(:exercise_with_guide) { create(:exercise, guide: guide, number: 2) }
       let!(:alternative_exercise) { create(:exercise, guide: guide, number: 3) }
       let(:guide) { create(:guide) }
@@ -145,7 +147,7 @@ describe Exercise do
     end
   end
 
-  describe '#extra_preview' do
+  describe '#extra_preview', organization_workspace: :test do
     let(:haskell) { create(:haskell) }
     let(:guide) { create(:guide,
                          extra: 'f x = 1',
@@ -158,7 +160,7 @@ describe Exercise do
     it { expect(exercise.assignment_for(user).extra_preview).to eq "```haskell\nf x = 1\ng y = y + 3\n```" }
   end
 
-  describe '#submit_solution!' do
+  describe '#submit_solution!', organization_workspace: :test do
     context 'when user did a submission' do
       before { exercise.submit_solution!(user) }
       it { expect(exercise.find_assignment_for(user)).to be_present }
@@ -173,7 +175,7 @@ describe Exercise do
       it { exercise.destroy! }
     end
 
-    context 'when there are submissions' do
+    context 'when there are submissions', organization_workspace: :test do
       let!(:assignment) { create(:assignment, exercise: exercise) }
       before { exercise.destroy! }
       it { expect { Assignment.find(assignment.id) }.to raise_error(ActiveRecord::RecordNotFound) }
@@ -399,13 +401,12 @@ describe Exercise do
     end
   end
 
-  describe '#guide_done_for?' do
-
+  describe '#guide_done_for?', organization_workspace: :test do
     context 'when it does not belong to a guide' do
       it { expect(exercise.guide_done_for?(user)).to be false }
     end
 
-    context 'when it belongs to a guide unfinished' do
+    context 'when it belongs to an unfinished guide' do
       let!(:guide) { create(:guide) }
       let!(:exercise_unfinished) { create(:exercise, guide: guide) }
       let!(:exercise_finished) { create(:exercise, guide: guide) }
@@ -417,7 +418,7 @@ describe Exercise do
       it { expect(exercise_finished.guide_done_for?(user)).to be false }
     end
 
-    context 'when it belongs to a guide unfinished' do
+    context 'when it belongs to a finished guide' do
       let!(:guide) { create(:guide) }
       let!(:exercise_finished) { create(:exercise, guide: guide) }
       let!(:exercise_finished2) { create(:exercise, guide: guide) }

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -53,20 +53,21 @@ describe Guide do
   describe '#clear_progress!', organization_workspace: :test do
     let(:an_exercise) { create(:exercise) }
     let(:another_exercise) { create(:exercise) }
+    let(:test_organization) { Organization.current }
 
     before do
       guide.exercises = [an_exercise]
       an_exercise.submit_solution! extra_user
       another_exercise.submit_solution! extra_user
-      guide.clear_progress!(extra_user)
+      guide.clear_progress!(extra_user, test_organization)
     end
 
     it 'destroys the guides assignments for the given user' do
-      expect(an_exercise.find_assignment_for(extra_user)).to be_nil
+      expect(an_exercise.find_assignment_for(extra_user, test_organization)).to be_nil
     end
 
     it 'does not destroy other guides assignments' do
-      expect(another_exercise.find_assignment_for(extra_user)).to be_truthy
+      expect(another_exercise.find_assignment_for(extra_user, test_organization)).to be_truthy
     end
   end
 

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -50,7 +50,7 @@ describe Guide do
     end
   end
 
-  describe '#clear_progress!' do
+  describe '#clear_progress!', organization_workspace: :test do
     let(:an_exercise) { create(:exercise) }
     let(:another_exercise) { create(:exercise) }
 

--- a/spec/models/interactive_spec.rb
+++ b/spec/models/interactive_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Interactive do
+describe Interactive, organization_workspace: :test do
   let!(:interactive) { create(:interactive) }
   let!(:user) { create(:user) }
   let(:assignment) { interactive.assignment_for(user) }

--- a/spec/models/problem_spec.rb
+++ b/spec/models/problem_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Problem do
+describe Problem, organization_workspace: :test do
 
   context 'when no manual evaluation and' do
     before { problem.manual_evaluation = false }

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -11,7 +11,7 @@ describe Mumuki::Domain::Submission::Query do
 
   describe '#submit_query!', organization_workspace: :test do
     let!(:results) { exercise.submit_query!(user, query: 'foo', content: 'bar', cookie: ['foo', 'bar']) }
-    let(:assignment) { exercise.find_assignment_for user }
+    let(:assignment) { exercise.find_assignment_for(user, Organization.current) }
 
     it { expect(results[:status]).to eq :passed }
     it { expect(results[:result]).to eq '5' }

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -9,7 +9,7 @@ describe Mumuki::Domain::Submission::Query do
     allow_any_instance_of(Language).to receive(:run_query!).and_return(status: :passed, result: '5')
   end
 
-  describe '#submit_query!' do
+  describe '#submit_query!', organization_workspace: :test do
     let!(:results) { exercise.submit_query!(user, query: 'foo', content: 'bar', cookie: ['foo', 'bar']) }
     let(:assignment) { exercise.find_assignment_for user }
 

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -5,7 +5,7 @@ describe Mumuki::Domain::Submission::Query, organization_workspace: :test do
   let(:student) { create(:user) }
 
   describe '#submit_question!' do
-    let(:assignment) { exercise.find_assignment_for student }
+    let(:assignment) { exercise.find_assignment_for(student, Organization.current) }
 
     context 'when just a question on an empty assignment is sent' do
       before { exercise.submit_question!(student, content: 'Please help!') }

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Mumuki::Domain::Submission::Query do
+describe Mumuki::Domain::Submission::Query, organization_workspace: :test do
   let!(:exercise) { create(:problem) }
   let(:student) { create(:user) }
 

--- a/spec/models/reading_spec.rb
+++ b/spec/models/reading_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Reading do
+describe Reading, organization_workspace: :test do
   let!(:reading) { create(:reading) }
   let!(:user) { create(:user) }
 

--- a/spec/models/solution_spec.rb
+++ b/spec/models/solution_spec.rb
@@ -16,9 +16,9 @@ describe Mumuki::Domain::Submission::Solution, organization_workspace: :test do
       before { reindex_current_organization! }
       let!(:result) { problem.try_submit_solution! user }
 
-      it { expect(result).to eq problem.find_assignment_for(user) }
-      it { expect(result.attempts_left).to eq nil  }
-      it { expect(result.attempts_left?).to be true  }
+      it { expect(result).to eq problem.find_assignment_for(user, Organization.current) }
+      it { expect(result.attempts_left).to eq nil }
+      it { expect(result.attempts_left?).to be true }
     end
 
     context 'when on exam' do
@@ -28,9 +28,9 @@ describe Mumuki::Domain::Submission::Solution, organization_workspace: :test do
       before { reindex_current_organization! }
       let(:result) { problem.try_submit_solution! user }
 
-      it { expect(result).to eq problem.find_assignment_for(user) }
-      it { expect(result.attempts_left).to eq 9  }
-      it { expect(result.attempts_left?).to be true  }
+      it { expect(result).to eq problem.find_assignment_for(user, Organization.current) }
+      it { expect(result.attempts_left).to eq 9 }
+      it { expect(result.attempts_left?).to be true }
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,9 +25,7 @@ RSpec.configure do |config|
 
   config.before(:each) do
     if RSpec.current_example.metadata[:organization_workspace] == :test
-      create(:public_organization,
-          name: 'test',
-          book: create(:book, name: 'test', slug: 'mumuki/mumuki-the-book')).switch!
+      create(:test_organization).switch!
     end
   end
 


### PR DESCRIPTION
Adds reference so we can keep track of each new assignment's organization.

Old assigmnents, in the meantime, remain with no organization