### PR TITLE
Optimizing tests

### DIFF
--- a/spec/models/book_import_spec.rb
+++ b/spec/models/book_import_spec.rb
@@ -43,14 +43,18 @@ describe Book do
 
       before { book.import_from_resource_h!(book_resource_h) }
 
-      it { expect(book.name).to eq 'sample book' }
-      it { expect(book.description).to eq 'a sample book description' }
-      it { expect(book.locale).to eq 'en' }
-      it { expect(book.chapters.count).to eq 2 }
-      it { expect(book.complements.count).to eq 2 }
+      it 'imports data succesfully' do
+        expect(book.name).to eq 'sample book'
+        expect(book.description).to eq 'a sample book description'
+        expect(book.locale).to eq 'en'
+        expect(book.chapters.count).to eq 2
+        expect(book.complements.count).to eq 2
+      end
 
-      it { expect(topic_2.reload.usage_in_organization).to be_a Chapter }
-      it { expect(guide_2.reload.usage_in_organization).to be_a Complement }
+      it 'reindexes usages properly' do
+        expect(topic_2.reload.usage_in_organization).to be_a Chapter
+        expect(guide_2.reload.usage_in_organization).to be_a Complement
+      end
 
       it { expect(book.sync_key).to eq Mumukit::Sync.key(Book, 'mumuki/a-book') }
     end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -31,18 +31,19 @@ describe Book, organization_workspace: :test do
     shared_examples_for 'a successful fork operation' do
       let!(:new_book) { original_book.fork_to! 'new', Mumukit::Sync::Syncer.new(Mumukit::Sync::Store::NullStore.new) }
 
-      it { expect(new_book.slug).to eq 'new/book' }
-      it { expect(new_book.chapters.map(&:slug)).to eq %w(new/topic1 new/topic2) }
-      it { expect(new_guides.map(&:slug)).to eq %w(new/guide1 new/guide2 new/guide3 new/guide4) }
+      it "forks properly" do
+        expect(new_book.slug).to eq 'new/book'
+        expect(new_book.chapters.map(&:slug)).to eq %w(new/topic1 new/topic2)
+        expect(new_guides.map(&:slug)).to eq %w(new/guide1 new/guide2 new/guide3 new/guide4)
 
-      it { expect(Book.find_by_slug 'new/book').to be_present }
-      it { expect(Topic.find_by_slug 'new/topic1').to be_present }
-      it { expect(Topic.find_by_slug 'new/topic2').to be_present }
-
-      it { expect(Guide.find_by_slug 'new/guide1').to be_present }
-      it { expect(Guide.find_by_slug 'new/guide2').to be_present }
-      it { expect(Guide.find_by_slug 'new/guide3').to be_present }
-      it { expect(Guide.find_by_slug 'new/guide4').to be_present }
+        expect(Book.find_by_slug 'new/book').to be_present
+        expect(Topic.find_by_slug 'new/topic1').to be_present
+        expect(Topic.find_by_slug 'new/topic2').to be_present
+        expect(Guide.find_by_slug 'new/guide1').to be_present
+        expect(Guide.find_by_slug 'new/guide2').to be_present
+        expect(Guide.find_by_slug 'new/guide3').to be_present
+        expect(Guide.find_by_slug 'new/guide4').to be_present
+      end
     end
 
     context 'when no content has been previously forked' do
@@ -88,15 +89,18 @@ describe Book, organization_workspace: :test do
         chapter_2.rebuild!([lesson_3])
       end
 
-      it { expect(book.description).to eq '#foo' }
-      it { expect(book.description_html).to eq "<h1>foo</h1>\n" }
 
-      it { expect(Chapter.count).to eq 2 }
-      it { expect(book.chapters).to eq [chapter_1, chapter_2] }
-      it { expect(chapter_1.guides).to eq [guide_1, guide_2] }
-      it { expect(chapter_2.guides).to eq [guide_3] }
-      it { expect(chapter_1.number).to eq 1 }
-      it { expect(chapter_2.number).to eq 2 }
+      it "rebuilds successfully" do
+        expect(book.description).to eq '#foo'
+        expect(book.description_html).to eq "<h1>foo</h1>\n"
+
+        expect(Chapter.count).to eq 2
+        expect(book.chapters).to eq [chapter_1, chapter_2]
+        expect(chapter_1.guides).to eq [guide_1, guide_2]
+        expect(chapter_2.guides).to eq [guide_3]
+        expect(chapter_1.number).to eq 1
+        expect(chapter_2.number).to eq 2
+      end
     end
 
     context 'when some chapters are orphan' do
@@ -109,16 +113,18 @@ describe Book, organization_workspace: :test do
         chapter_2.rebuild!([lesson_3])
       end
 
-      it { expect(book.description).to eq '#foo' }
-      it { expect(book.description_html).to eq "<h1>foo</h1>\n" }
+      it "rebuilds successfully" do
+        expect(book.description).to eq '#foo'
+        expect(book.description_html).to eq "<h1>foo</h1>\n"
 
-      it { expect(Chapter.count).to eq 3 }
-      it { expect(book.chapters).to eq [chapter_1, orphan_chapter, chapter_2] }
-      it { expect(chapter_1.guides).to eq [guide_1, guide_2] }
-      it { expect(chapter_2.guides).to eq [guide_3] }
-      it { expect(chapter_1.number).to eq 1 }
-      it { expect(orphan_chapter.number).to eq 2 }
-      it { expect(chapter_2.number).to eq 3 }
+        expect(Chapter.count).to eq 3
+        expect(book.chapters).to eq [chapter_1, orphan_chapter, chapter_2]
+        expect(chapter_1.guides).to eq [guide_1, guide_2]
+        expect(chapter_2.guides).to eq [guide_3]
+        expect(chapter_1.number).to eq 1
+        expect(orphan_chapter.number).to eq 2
+        expect(chapter_2.number).to eq 3
+      end
     end
 
 
@@ -134,15 +140,17 @@ describe Book, organization_workspace: :test do
         chapter_2.rebuild!([lesson_3])
       end
 
-      it { expect(book.description).to eq '#foo' }
-      it { expect(book.description_html).to eq "<h1>foo</h1>\n" }
+      it "rebuilds successfully" do
+        expect(book.description).to eq '#foo'
+        expect(book.description_html).to eq "<h1>foo</h1>\n"
 
-      it { expect(Chapter.count).to eq 2 }
-      it { expect(book.chapters).to eq [chapter_1, chapter_2] }
-      it { expect(chapter_1.guides).to eq [guide_1, guide_2] }
-      it { expect(chapter_2.guides).to eq [guide_3] }
-      it { expect(chapter_1.number).to eq 1 }
-      it { expect(chapter_2.number).to eq 2 }
+        expect(Chapter.count).to eq 2
+        expect(book.chapters).to eq [chapter_1, chapter_2]
+        expect(chapter_1.guides).to eq [guide_1, guide_2]
+        expect(chapter_2.guides).to eq [guide_3]
+        expect(chapter_1.number).to eq 1
+        expect(chapter_2.number).to eq 2
+      end
     end
 
     context 'when chapter is rebuilt before book rebuilt' do
@@ -154,15 +162,17 @@ describe Book, organization_workspace: :test do
         book.rebuild!([chapter_1, chapter_2])
       end
 
-      it { expect(book.description).to eq '#foo' }
-      it { expect(book.description_html).to eq "<h1>foo</h1>\n" }
+      it "rebuilds successfully" do
+        expect(book.description).to eq '#foo'
+        expect(book.description_html).to eq "<h1>foo</h1>\n"
 
-      it { expect(Chapter.count).to eq 2 }
-      it { expect(book.chapters).to eq [chapter_1, chapter_2] }
-      it { expect(chapter_1.number).to eq 1 }
-      it { expect(chapter_2.number).to eq 2 }
-      it { expect(chapter_1.guides).to eq [guide_1, guide_2] }
-      it { expect(chapter_2.guides).to eq [guide_3] }
+        expect(Chapter.count).to eq 2
+        expect(book.chapters).to eq [chapter_1, chapter_2]
+        expect(chapter_1.number).to eq 1
+        expect(chapter_2.number).to eq 2
+        expect(chapter_1.guides).to eq [guide_1, guide_2]
+        expect(chapter_2.guides).to eq [guide_3]
+      end
     end
   end
 end

--- a/spec/models/guide_import_spec.rb
+++ b/spec/models/guide_import_spec.rb
@@ -114,13 +114,13 @@ describe Guide do
         guide.import_from_resource_h!(guide_resource_h)
       end
 
-      describe 'it is removed from the guide' do
-        it { expect(guide.exercises.count).to eq 5 }
-        it { expect(guide.exercises).not_to include exercise_6 }
+      it 'is removed from the guide' do
+        expect(guide.exercises.count).to eq 5
+        expect(guide.exercises).not_to include exercise_6
       end
 
-      describe 'it is deleted from the database' do
-        it { expect { Exercise.find(exercise_6.id) }.to raise_error(ActiveRecord::RecordNotFound) }
+      it 'is deleted from the database' do
+        expect { Exercise.find(exercise_6.id) }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
@@ -132,26 +132,35 @@ describe Guide do
         guide.import_from_resource_h!(guide_resource_h)
       end
 
-      it { expect(guide).to_not be nil }
-      it { expect(guide.name).to eq 'sample guide' }
-      it { expect(guide.language).to eq haskell }
-      it { expect(guide.slug).to eq 'mumuki/sample-guide' }
-      it { expect(guide.extra).to eq 'bar' }
-      it { expect(guide.description).to eq 'Baz' }
+      it 'imports basic fields' do
+        expect(guide).to_not be nil
+        expect(guide.name).to eq 'sample guide'
+        expect(guide.language).to eq haskell
+        expect(guide.slug).to eq 'mumuki/sample-guide'
+        expect(guide.extra).to eq 'bar'
+        expect(guide.description).to eq 'Baz'
+      end
 
-      it { expect(guide.exercises.count).to eq 5 }
-      it { expect(guide.exercises.first.language).to eq gobstones }
-      it { expect(guide.exercises.first.extra_visible).to be false }
-      it { expect(guide.exercises.first.assistance_rules).to be_present }
-      it { expect(guide.exercises.first.assistant.rules.count).to eq 2 }
+      it 'imports first exercise' do
+        expect(guide.exercises.count).to eq 5
+        expect(guide.exercises.first.language).to eq gobstones
+        expect(guide.exercises.first.extra_visible).to be false
+        expect(guide.exercises.first.assistance_rules).to be_present
+        expect(guide.exercises.first.assistant.rules.count).to eq 2
+      end
 
-      it { expect(guide.exercises.second.language).to eq haskell }
-      it { expect(guide.exercises.second.default_content).to eq 'a default content' }
-      it { expect(guide.exercises.second.extra_visible).to be true }
-      it { expect(guide.exercises.fourth.choices).to eq [{'value' => 'foo', 'checked' => false}, {'value' => 'bar', 'checked' => true}] }
-      it { expect(guide.exercises.fourth.choice_values).to eq ['foo', 'bar'] }
+      it 'imports second exercise' do
+        expect(guide.exercises.second.language).to eq haskell
+        expect(guide.exercises.second.default_content).to eq 'a default content'
+        expect(guide.exercises.second.extra_visible).to be true
+      end
 
       it { expect(guide.exercises.third.expectations.first['binding']).to eq 'foo' }
+
+      it 'imports fourth exercise' do
+        expect(guide.exercises.fourth.choices).to eq [{'value' => 'foo', 'checked' => false}, {'value' => 'bar', 'checked' => true}]
+        expect(guide.exercises.fourth.choice_values).to eq ['foo', 'bar']
+      end
 
       it { expect(guide.exercises.pluck(:name)).to eq %W(Bar Foo Baz Choice Reading) }
     end
@@ -170,13 +179,15 @@ describe Guide do
                                  name: 'Exercise 1',
                                  description: 'description') }
 
-        describe 'exercises are not duplicated' do
-          it { expect(guide.exercises.count).to eq 5 }
-          it { expect(Exercise.count).to eq 5 }
+        it 'exercises are not duplicated' do
+          expect(guide.exercises.count).to eq 5
+          expect(Exercise.count).to eq 5
         end
 
-        it { expect(guide.exercises.first).to be_instance_of(Problem) }
-        it { expect(guide.exercises.first).to eq reloaded_exercise_1 }
+        it 'changes type properly' do
+          expect(guide.exercises.first).to be_instance_of(Problem)
+          expect(guide.exercises.first).to eq reloaded_exercise_1
+        end
       end
 
       context 'when exercise doesnt have choices anymore' do
@@ -210,9 +221,9 @@ describe Guide do
 
         it { expect(guide.exercises.pluck(:bibliotheca_id)).to eq [1, 4, 2, 8, 9] }
 
-        describe 'exercises are not duplicated' do
-          it { expect(guide.exercises.count).to eq 5 }
-          it { expect(Exercise.count).to eq 5 }
+        it 'exercises are not duplicated' do
+          expect(guide.exercises.count).to eq 5
+          expect(Exercise.count).to eq 5
         end
       end
     end
@@ -245,22 +256,28 @@ describe Guide do
         guide.import_from_resource_h! guide_resource_h
       end
 
-      describe 'exercises are not duplicated' do
-        it { expect(guide.exercises.count).to eq 5 }
-        it { expect(Exercise.count).to eq 5 }
+      it 'exercises are not duplicated' do
+        expect(guide.exercises.count).to eq 5
+        expect(Exercise.count).to eq 5
       end
 
-      it { expect(guide.exercises.first).to be_instance_of(Problem) }
-      it { expect(guide.exercises.second).to be_instance_of(Playground) }
-      it { expect(guide.exercises.third).to be_instance_of(Problem) }
+      it 'load types properly' do
+        expect(guide.exercises.first).to be_instance_of(Problem)
+        expect(guide.exercises.second).to be_instance_of(Playground)
+        expect(guide.exercises.third).to be_instance_of(Problem)
+      end
 
-      it { expect(guide.exercises.second).to eq reloaded_exercise_2 }
-      it { expect(guide.exercises.third).to eq reloaded_exercise_1 }
+      it 'loads exercises properly' do
+        expect(guide.exercises.second).to eq reloaded_exercise_2
+        expect(guide.exercises.third).to eq reloaded_exercise_1
+      end
 
-      it { expect(guide.exercises.first.number).to eq 1 }
-      it { expect(guide.exercises.second.number).to eq 2 }
-      it { expect(guide.exercises.third.number).to eq 3 }
-      it { expect(guide.exercises.fourth.number).to eq 4 }
+      it 'loads exercises order properly' do
+        expect(guide.exercises.first.number).to eq 1
+        expect(guide.exercises.second.number).to eq 2
+        expect(guide.exercises.third.number).to eq 3
+        expect(guide.exercises.fourth.number).to eq 4
+      end
 
       it { expect(guide.exercises.pluck(:bibliotheca_id)).to eq [1, 4, 2, 8, 9] }
       it { expect(guide.exercises.pluck(:id).drop(1)).to eq [reloaded_exercise_2.id, reloaded_exercise_1.id, guide.exercises.fourth.id, guide.exercises.fifth.id] }
@@ -293,8 +310,10 @@ describe Guide do
         guide.import_from_resource_h! guide_resource_h
       end
 
-      it { expect(guide.exercises.first.new_expectations).to be_truthy }
-      it { expect(guide.exercises.first.expectations).to eq [] }
+      it 'load expectations properly' do
+        expect(guide.exercises.first.new_expectations).to be_truthy
+        expect(guide.exercises.first.expectations).to eq []
+      end
     end
   end
 end

--- a/spec/models/navigation_spec.rb
+++ b/spec/models/navigation_spec.rb
@@ -42,29 +42,37 @@ describe 'Navigation', organization_workspace: :test do
   before { reindex_organization! organization_1 }
   before { reindex_organization! organization_2 }
 
-  it { expect(book_1.complements.first.used_in? Organization.current).to be false }
-  it { expect(book_1.complements.first.used_in? organization_1).to be true }
-  it { expect(book_1.complements.first.used_in? organization_2).to be false }
+  it 'works with complements' do
+    expect(book_1.complements.first.used_in? Organization.current).to be false
+    expect(book_1.complements.first.used_in? organization_1).to be true
+    expect(book_1.complements.first.used_in? organization_2).to be false
 
-  it { expect(book_2.complements.first.used_in? Organization.current).to be false }
-  it { expect(book_2.complements.first.used_in? organization_1).to be false }
-  it { expect(book_2.complements.first.used_in? organization_2).to be true }
+    expect(book_2.complements.first.used_in? Organization.current).to be false
+    expect(book_2.complements.first.used_in? organization_1).to be false
+    expect(book_2.complements.first.used_in? organization_2).to be true
+  end
 
-  it { expect(chapter_1.used_in? organization_1).to be true }
-  it { expect(chapter_1.used_in? organization_2).to be false }
+  it 'works with chapters' do
+    expect(chapter_1.used_in? organization_1).to be true
+    expect(chapter_1.used_in? organization_2).to be false
 
-  it { expect(chapter_2.used_in? organization_1).to be false }
-  it { expect(chapter_2.used_in? organization_2).to be true }
+    expect(chapter_2.used_in? organization_1).to be false
+    expect(chapter_2.used_in? organization_2).to be true
+  end
 
-  it { expect(lesson_1.used_in? organization_1).to be true }
-  it { expect(lesson_1.used_in? organization_2).to be false }
+  it 'works with lessons' do
+    expect(lesson_1.used_in? organization_1).to be true
+    expect(lesson_1.used_in? organization_2).to be false
 
-  it { expect(lesson_2.used_in? organization_1).to be false }
-  it { expect(lesson_2.used_in? organization_2).to be true }
+    expect(lesson_2.used_in? organization_1).to be false
+    expect(lesson_2.used_in? organization_2).to be true
+  end
 
-  it { expect(exercise_1.used_in? organization_1).to be true }
-  it { expect(exercise_1.used_in? organization_2).to be false }
+  it 'works with exercsies' do
+    expect(exercise_1.used_in? organization_1).to be true
+    expect(exercise_1.used_in? organization_2).to be false
 
-  it { expect(exercise_2.used_in? organization_1).to be false }
-  it { expect(exercise_2.used_in? organization_2).to be true }
+    expect(exercise_2.used_in? organization_1).to be false
+    expect(exercise_2.used_in? organization_2).to be true
+  end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -117,13 +117,15 @@ describe Organization, organization_workspace: :test do
 
     before { reindex_current_organization! }
 
-    it { expect(organization.in_path? orphan_guide).to be false }
-    it { expect(organization.in_path? orphan_exercise).to be false }
+    it 'build path properly' do
+      expect(organization.in_path? orphan_guide).to be false
+      expect(organization.in_path? orphan_exercise).to be false
 
-    it { expect(organization.in_path? chapter_in_path).to be true }
-    it { expect(organization.in_path? topic_in_path).to be true }
-    it { expect(organization.in_path? lesson_in_path).to be true }
-    it { expect(organization.in_path? guide_in_path).to be true }
+      expect(organization.in_path? chapter_in_path).to be true
+      expect(organization.in_path? topic_in_path).to be true
+      expect(organization.in_path? lesson_in_path).to be true
+      expect(organization.in_path? guide_in_path).to be true
+    end
   end
 
   describe 'login_settings' do

--- a/spec/models/usage_spec.rb
+++ b/spec/models/usage_spec.rb
@@ -23,28 +23,35 @@ describe Usage do
   let!(:central) { create(:organization, name: 'central', book: programming) }
   let!(:pdep) { create(:organization, name: 'pdep', book: paradigms) }
 
+  shared_examples_for 'something that does not interfere with normal scopes' do
+    it 'does not affect all-scope' do
+      expect(Topic.all.count).to eq 4
+      expect(Chapter.all.count).to eq 7
+      expect(Book.all.count).to eq 2
+      expect(Organization.all.count).to eq 2
+    end
+  end
+
   context 'on central' do
     before { central.switch! }
 
-    it { expect(Topic.all.count).to eq 4 }
-    it { expect(Chapter.all.count).to eq 7 }
-    it { expect(Book.all.count).to eq 2 }
-    it { expect(Organization.all.count).to eq 2 }
+    it_behaves_like 'something that does not interfere with normal scopes'
 
-    it { expect(Organization.current).to eq central }
     it { expect(central.book).to eq programming }
 
     it { expect(programming.chapters.count).to eq 4 }
     it { expect(programming.chapters.map(&:topic)).to eq [fundamentals, functional_programming, oop, logic_programming] }
 
-    it { expect(fundamentals.usage_in_organization).to_not be_nil }
-    it { expect(fundamentals.usage_in_organization.number).to eq 1 }
+    it 'usage_in_organization behaves properly' do
+      expect(fundamentals.usage_in_organization).to_not be_nil
+      expect(fundamentals.usage_in_organization.number).to eq 1
 
-    it { expect(functional_programming.usage_in_organization).to_not be_nil }
-    it { expect(functional_programming.usage_in_organization).to be_a(Chapter) }
-    it { expect(functional_programming.usage_in_organization.number).to eq 2 }
-    it { expect(oop.usage_in_organization.number).to eq 3 }
-    it { expect(logic_programming.usage_in_organization.number).to eq 4 }
+      expect(functional_programming.usage_in_organization).to_not be_nil
+      expect(functional_programming.usage_in_organization).to be_a(Chapter)
+      expect(functional_programming.usage_in_organization.number).to eq 2
+      expect(oop.usage_in_organization.number).to eq 3
+      expect(logic_programming.usage_in_organization.number).to eq 4
+    end
 
     it { expect(Usage.in_organization.count).to eq 5  }
 
@@ -53,24 +60,22 @@ describe Usage do
   context 'on pdep' do
     before { pdep.switch! }
 
-    it { expect(Topic.all.count).to eq 4 }
-    it { expect(Chapter.all.count).to eq 7 }
-    it { expect(Book.all.count).to eq 2 }
-    it { expect(Organization.all.count).to eq 2 }
+    it_behaves_like 'something that does not interfere with normal scopes'
 
-    it { expect(Organization.current).to eq pdep }
     it { expect(pdep.book).to eq paradigms }
 
     it { expect(paradigms.chapters.count).to eq 3 }
     it { expect(paradigms.chapters.map(&:topic)).to eq [functional_programming, logic_programming, oop] }
 
-    it { expect(fundamentals.usage_in_organization).to be_nil }
+    it 'usage_in_organization behaves properly' do
+      expect(fundamentals.usage_in_organization).to be_nil
 
-    it { expect(functional_programming.usage_in_organization).to_not be_nil }
-    it { expect(functional_programming.usage_in_organization).to be_a(Chapter) }
-    it { expect(functional_programming.usage_in_organization.number).to eq 1 }
-    it { expect(logic_programming.usage_in_organization.number).to eq 2 }
-    it { expect(oop.usage_in_organization.number).to eq 3 }
+      expect(functional_programming.usage_in_organization).to_not be_nil
+      expect(functional_programming.usage_in_organization).to be_a(Chapter)
+      expect(functional_programming.usage_in_organization.number).to eq 1
+      expect(logic_programming.usage_in_organization.number).to eq 2
+      expect(oop.usage_in_organization.number).to eq 3
+    end
 
     it { expect(Usage.in_organization.count).to eq 4  }
   end


### PR DESCRIPTION
This change boosts test performance on ~50%. 

Test took ~45s on my machine. Now they take ~30s. 

My proposal here is to group database tests with expensive fixtures into just a few ones. 

Check http://www.betterspecs.org/#single

Also, I used `--profile` flag of `rspec` to find the bottlenecks. 

