### PR TITLE
Deprecate choice values column

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -108,7 +108,7 @@ class Exercise < ApplicationRecord
   end
 
   def choice_values
-    self[:choice_values].presence || choices.map { |it| it.indifferent_get(:value) }
+    choices.map { |it| it.indifferent_get(:value) }
   end
 
   def choice_index_for(value)

--- a/db/migrate/20191022180238_remove_choice_values_from_exercises.rb
+++ b/db/migrate/20191022180238_remove_choice_values_from_exercises.rb
@@ -1,5 +1,5 @@
 class RemoveChoiceValuesFromExercises < ActiveRecord::Migration[5.1]
   def change
-    remove_column :exercises, :choice_values, :string
+    remove_column :exercises, :choice_values, :string, array: true, default: [], null: false
   end
 end

--- a/db/migrate/20191022180238_remove_choice_values_from_exercises.rb
+++ b/db/migrate/20191022180238_remove_choice_values_from_exercises.rb
@@ -1,0 +1,5 @@
+class RemoveChoiceValuesFromExercises < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :exercises, :choice_values, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190929180601) do
+ActiveRecord::Schema.define(version: 20191022180238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -162,7 +162,6 @@ ActiveRecord::Schema.define(version: 20190929180601) do
     t.boolean "extra_visible", default: false
     t.boolean "manual_evaluation", default: false
     t.integer "editor", default: 0, null: false
-    t.string "choice_values", default: [], null: false, array: true
     t.text "goal"
     t.string "initial_state"
     t.string "final_state"

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -12,17 +12,6 @@ describe Exercise do
   end
 
   describe '#choice_values' do
-    context 'when choices are in 5.0 format' do
-      let(:choice_values) { %w(1492 1453 1773)  }
-      let(:exercise) { build(:exercise, description: 'when did byzantine empire fall?', choice_values: choice_values) }
-
-      it { expect(exercise.choices).to be_blank }
-      it { expect(exercise[:choice_values]).to eq choice_values }
-      it { expect(exercise.choice_values).to eq choice_values }
-      it { expect(exercise.choice_index_for '1492').to eq 0 }
-      it { expect(exercise.choice_index_for '1773').to eq 2 }
-    end
-
     context 'when choices are in 6.0 format' do
       let(:choices) { [{value: '1492', checked: false}, {value: '1453', checked: true}, {value: '1773', checked: false}] }
       let(:exercise) { build(:exercise, description: 'when did byzantine empire fall?', choices: choices) }


### PR DESCRIPTION
:warning: This is a non backwards compatible change! :warning:
We're not using this field in any exercises though, so it doesn't really make any sense still having it there.