### PR TITLE
Extending resource markdownification

### DIFF
--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -8,11 +8,11 @@ class Content < ApplicationRecord
   include WithUsages
   include WithName
 
-  def to_resource_h
-    to_expanded_resource_h.compact
+  def to_resource_h(*args)
+    to_expanded_resource_h(*args).compact
   end
 
-  def to_expanded_resource_h
+  def to_expanded_resource_h(*)
     as_json(only: [:name, :slug, :description, :locale]).symbolize_keys
   end
 

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -115,13 +115,13 @@ class Exercise < ApplicationRecord
     choice_values.index(value)
   end
 
-  def to_resource_h
-    to_expanded_resource_h.compact
+  def to_resource_h(*args)
+    to_expanded_resource_h(*args).compact
   end
 
   # Keep this list up to date with
   # Mumuki::Domain::Store::ExerciseSchema
-  def to_expanded_resource_h
+  def to_expanded_resource_h(options={})
     language_resource_h = language.to_embedded_resource_h if language != guide.language
     as_json(only: BASIC_RESOURCE_FIELDS)
       .merge(id: bibliotheca_id, language: language_resource_h, type: type.underscore)
@@ -130,6 +130,7 @@ class Exercise < ApplicationRecord
       .merge(settings: self[:settings])
       .merge(RANDOMIZED_FIELDS.map { |it| [it, self[it]] }.to_h)
       .symbolize_keys
+      .tap { |it| it.markdownify!(:hint, :corollary, :description, :teacher_info) if options[:markdownified] }
   end
 
   def reset!

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -93,23 +93,17 @@ class Guide < Content
 
   # Keep this list up to date with
   # Mumuki::Domain::Store::Github::GuideSchema
-  def to_expanded_resource_h
+  def to_expanded_resource_h(options={})
     as_json(only: BASIC_RESOURCE_FIELDS)
       .symbolize_keys
       .merge(super)
-      .merge(exercises: exercises.map(&:to_resource_h))
+      .merge(exercises: exercises.map { |it| it.to_resource_h(options) })
       .merge(language: language.to_embedded_resource_h)
+      .tap { |it| it.markdownify!(:corollary, :description, :teacher_info) if options[:markdownified] }
   end
 
   def to_markdownified_resource_h
-    to_resource_h.tap do |guide|
-      %i(corollary description teacher_info).each do |it|
-        guide[it] = Mumukit::ContentType::Markdown.to_html(guide[it])
-      end
-      %i(hint corollary description teacher_info).each do |it|
-        guide[:exercises].each { |exercise| exercise[it] = Mumukit::ContentType::Markdown.to_html(exercise[it]) }
-      end
-    end
+    to_resource_h(markdownified: true)
   end
 
   def as_lesson_of(topic)

--- a/lib/mumuki/domain/extensions.rb
+++ b/lib/mumuki/domain/extensions.rb
@@ -1,3 +1,4 @@
 require_relative './extensions/string'
 require_relative './extensions/array'
 require_relative './extensions/module'
+require_relative './extensions/hash'

--- a/lib/mumuki/domain/extensions/hash.rb
+++ b/lib/mumuki/domain/extensions/hash.rb
@@ -1,0 +1,5 @@
+class Hash
+  def markdownify!(*keys)
+    keys.each { |it| self[it] = Mumukit::ContentType::Markdown.to_html(self[it]) }
+  end
+end

--- a/spec/models/hash_spec.rb
+++ b/spec/models/hash_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Hash do
+  describe 'markdown_paragraphs' do
+    let(:hash) { { something: 'hello **world**', something_else: '`the code`', other: '_foo_' } }
+
+    before { hash.markdownify! :something, :something_else }
+
+    it { expect(hash).to eq other: "_foo_", something: "<p>hello <strong>world</strong></p>\n", something_else: "<p><code>the code</code></p>\n" }
+  end
+end


### PR DESCRIPTION
This is a refactor of `to_markdownified_resource_h`, that better delegates the exercise logic into the... exercise class :stuck_out_tongue: . 

It also allows future extensions of `to_resource_h`. 