### PR TITLE
Feature partial usage tree remake

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -67,7 +67,7 @@ class ApplicationRecord < ActiveRecord::Base
 
   def self.aggregate_of(association)
     class_eval do
-      define_method(:rebuild!) do |children|
+      define_method("rebuild_#{association}!") do |children|
         transaction do
           self.send(association).all_except(children).destroy_all
           self.update! association => children

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -69,7 +69,7 @@ class ApplicationRecord < ActiveRecord::Base
     class_eval do
       define_method(:rebuild!) do |children|
         transaction do
-          self.send(association).all_except(children).delete_all
+          self.send(association).all_except(children).destroy_all
           self.update! association => children
           children.each &:save!
         end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -23,8 +23,6 @@ class Book < Content
     user.try(:last_lesson)|| first_lesson
   end
 
-  after_save :reindex_usages!
-
   def import_from_resource_h!(resource_h)
     self.assign_attributes resource_h.except(:chapters, :complements, :id, :description)
     self.description = resource_h[:description]&.squeeze(' ')

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,6 +1,6 @@
 class Book < Content
   numbered :chapters
-  aggregate_of :chapters
+  content_aggregate_of :chapters
 
   has_many :chapters, -> { order(number: :asc) }, dependent: :destroy
   has_many :complements, dependent: :destroy
@@ -27,7 +27,7 @@ class Book < Content
     self.assign_attributes resource_h.except(:chapters, :complements, :id, :description)
     self.description = resource_h[:description]&.squeeze(' ')
 
-    rebuild! resource_h[:chapters].map { |it| Topic.find_by!(slug: it).as_chapter_of(self) }
+    rebuild_with_usages! resource_h[:chapters].map { |it| Topic.find_by!(slug: it).as_chapter_of(self) }
     rebuild_complements! resource_h[:complements].to_a.map { |it| Guide.find_by(slug: it)&.as_complement_of(self) }.compact
   end
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,6 +1,6 @@
 class Book < Content
   numbered :chapters
-  content_aggregate_of :chapters
+  aggregate_of :chapters
 
   has_many :chapters, -> { order(number: :asc) }, dependent: :destroy
   has_many :complements, dependent: :destroy
@@ -27,7 +27,7 @@ class Book < Content
     self.assign_attributes resource_h.except(:chapters, :complements, :id, :description)
     self.description = resource_h[:description]&.squeeze(' ')
 
-    rebuild_with_usages! resource_h[:chapters].map { |it| Topic.find_by!(slug: it).as_chapter_of(self) }
+    rebuild! resource_h[:chapters].map { |it| Topic.find_by!(slug: it).as_chapter_of(self) }
     rebuild_complements! resource_h[:complements].to_a.map { |it| Guide.find_by(slug: it)&.as_complement_of(self) }.compact
   end
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,6 +1,7 @@
 class Book < Content
   numbered :chapters
   aggregate_of :chapters
+  aggregate_of :complements
 
   has_many :chapters, -> { order(number: :asc) }, dependent: :destroy
   has_many :complements, dependent: :destroy
@@ -27,7 +28,7 @@ class Book < Content
     self.assign_attributes resource_h.except(:chapters, :complements, :id, :description)
     self.description = resource_h[:description]&.squeeze(' ')
 
-    rebuild! resource_h[:chapters].map { |it| Topic.find_by!(slug: it).as_chapter_of(self) }
+    rebuild_chapters! resource_h[:chapters].map { |it| Topic.find_by!(slug: it).as_chapter_of(self) }
     rebuild_complements! resource_h[:complements].to_a.map { |it| Guide.find_by(slug: it)&.as_complement_of(self) }.compact
   end
 
@@ -35,15 +36,6 @@ class Book < Content
     super.merge(
       chapters: chapters.map(&:slug),
       complements: complements.map(&:slug))
-  end
-
-  def rebuild_complements!(complements) #FIXME use rebuild
-    transaction do
-      self.complements.all_except(complements).delete_all
-      self.update! :complements => complements
-      complements.each &:save!
-    end
-    reload
   end
 
   def index_usage!(organization)

--- a/app/models/concerns/guide_container.rb
+++ b/app/models/concerns/guide_container.rb
@@ -1,8 +1,10 @@
 module GuideContainer
   extend ActiveSupport::Concern
+  include WithContent
 
   included do
     validates_presence_of :guide
+    before_destroy :destroy_usages!
 
     delegate :name,
              :slug,

--- a/app/models/concerns/guide_container.rb
+++ b/app/models/concerns/guide_container.rb
@@ -4,7 +4,6 @@ module GuideContainer
 
   included do
     validates_presence_of :guide
-    before_destroy :destroy_usages!
 
     delegate :name,
              :slug,

--- a/app/models/concerns/with_content.rb
+++ b/app/models/concerns/with_content.rb
@@ -1,0 +1,13 @@
+module WithContent
+  extend ActiveSupport::Concern
+
+  included do
+    before_destroy :destroy_usages!
+  end
+
+  private
+
+  def destroy_usages!
+    Usage.destroy_usages_for self
+  end
+end

--- a/app/models/concerns/with_usages.rb
+++ b/app/models/concerns/with_usages.rb
@@ -20,7 +20,7 @@ module WithUsages
     def aggregate_of(association)
       super
 
-      revamp :rebuild! do |_, this, children, hyper|
+      revamp "rebuild_#{association}!" do |_, this, children, hyper|
         old_children = this.send association
         added_children = children - old_children
         hyper.(children)

--- a/app/models/concerns/with_usages.rb
+++ b/app/models/concerns/with_usages.rb
@@ -17,16 +17,16 @@ module WithUsages
   end
 
   class_methods do
-    def content_aggregate_of(association)
-      aggregate_of association
+    def aggregate_of(association)
+      super
 
-      define_method :rebuild_with_usages! do |children|
-        old_children = send association
+      revamp :rebuild! do |_, this, children, hyper|
+        old_children = this.send association
         added_children = children - old_children
-        rebuild! children
-        usages.each { |it| it.index_children!(added_children) }
+        hyper.(children)
+        this.usages.each { |it| it.index_children!(added_children) }
 
-        self
+        this
       end
     end
   end

--- a/app/models/concerns/with_usages.rb
+++ b/app/models/concerns/with_usages.rb
@@ -24,7 +24,7 @@ module WithUsages
         old_children = send association
         added_children = children - old_children
         rebuild! children
-        usages.each { |it| it.index_children(added_children) }
+        usages.each { |it| it.index_children!(added_children) }
 
         self
       end

--- a/app/models/concerns/with_usages.rb
+++ b/app/models/concerns/with_usages.rb
@@ -16,6 +16,21 @@ module WithUsages
     item.is_a?(type) ? item : nil
   end
 
+  class_methods do
+    def content_aggregate_of(association)
+      aggregate_of association
+
+      define_method :rebuild_with_usages! do |children|
+        old_children = send association
+        added_children = children - old_children
+        rebuild! children
+        usages.each { |it| it.index_children(added_children) }
+
+        self
+      end
+    end
+  end
+
   private
 
   def ensure_unused!

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -9,8 +9,6 @@ class Topic < Content
 
   markdown_on :appendix
 
-  after_save :reindex_usages!
-
   def pending_lessons(user)
     guides.
         joins('left join public.exercises exercises

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,6 +1,6 @@
 class Topic < Content
   numbered :lessons
-  aggregate_of :lessons
+  content_aggregate_of :lessons
 
   has_many :lessons, -> { order(number: :asc) }, dependent: :delete_all
 
@@ -28,7 +28,7 @@ class Topic < Content
   def import_from_resource_h!(resource_h)
     self.assign_attributes resource_h.except(:lessons, :description)
     self.description = resource_h[:description].squeeze(' ')
-    rebuild! resource_h[:lessons].to_a.map { |it| lesson_for(it) }
+    rebuild_with_usages! resource_h[:lessons].to_a.map { |it| lesson_for(it) }
   end
 
   def to_expanded_resource_h

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,6 +1,6 @@
 class Topic < Content
   numbered :lessons
-  content_aggregate_of :lessons
+  aggregate_of :lessons
 
   has_many :lessons, -> { order(number: :asc) }, dependent: :delete_all
 
@@ -28,7 +28,7 @@ class Topic < Content
   def import_from_resource_h!(resource_h)
     self.assign_attributes resource_h.except(:lessons, :description)
     self.description = resource_h[:description].squeeze(' ')
-    rebuild_with_usages! resource_h[:lessons].to_a.map { |it| lesson_for(it) }
+    rebuild! resource_h[:lessons].to_a.map { |it| lesson_for(it) }
   end
 
   def to_expanded_resource_h

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -28,7 +28,7 @@ class Topic < Content
   def import_from_resource_h!(resource_h)
     self.assign_attributes resource_h.except(:lessons, :description)
     self.description = resource_h[:description].squeeze(' ')
-    rebuild! resource_h[:lessons].to_a.map { |it| lesson_for(it) }
+    rebuild_lessons! resource_h[:lessons].to_a.map { |it| lesson_for(it) }
   end
 
   def to_expanded_resource_h

--- a/app/models/topic_container.rb
+++ b/app/models/topic_container.rb
@@ -12,7 +12,7 @@ module TopicContainer
              :description,
              :description_html,
              :description_teaser_html,
-             :rebuild!,
+             :rebuild_lessons!,
              :lessons,
              :guides,
              :pending_guides,

--- a/app/models/topic_container.rb
+++ b/app/models/topic_container.rb
@@ -1,5 +1,7 @@
 module TopicContainer
   extend ActiveSupport::Concern
+  include WithContent
+
   included do
     validates_presence_of :topic
 

--- a/app/models/usage.rb
+++ b/app/models/usage.rb
@@ -12,6 +12,10 @@ class Usage < ApplicationRecord
     Usage.where(parent_item: record).destroy_all
   end
 
+  def index_children(children)
+    children.each { |it| it.index_usage! organization }
+  end
+
   private
 
   def set_slug

--- a/app/models/usage.rb
+++ b/app/models/usage.rb
@@ -12,7 +12,7 @@ class Usage < ApplicationRecord
     Usage.where(parent_item: record).destroy_all
   end
 
-  def index_children(children)
+  def index_children!(children)
     children.each { |it| it.index_usage! organization }
   end
 

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -83,10 +83,10 @@ describe Book, organization_workspace: :test do
     context 'when chapter is rebuilt after book rebuilt' do
       before do
         book.description = '#foo'
-        book.rebuild!([chapter_1, chapter_2])
+        book.rebuild_chapters!([chapter_1, chapter_2])
 
-        chapter_1.rebuild!([lesson_1, lesson_2])
-        chapter_2.rebuild!([lesson_3])
+        chapter_1.rebuild_lessons!([lesson_1, lesson_2])
+        chapter_2.rebuild_lessons!([lesson_3])
       end
 
 
@@ -107,10 +107,10 @@ describe Book, organization_workspace: :test do
       let(:orphan_chapter) { build(:chapter, book: nil) }
       before do
         book.description = '#foo'
-        book.rebuild!([chapter_1, orphan_chapter, chapter_2])
+        book.rebuild_chapters!([chapter_1, orphan_chapter, chapter_2])
 
-        chapter_1.rebuild!([lesson_1, lesson_2])
-        chapter_2.rebuild!([lesson_3])
+        chapter_1.rebuild_lessons!([lesson_1, lesson_2])
+        chapter_2.rebuild_lessons!([lesson_3])
       end
 
       it "rebuilds successfully" do
@@ -134,10 +134,10 @@ describe Book, organization_workspace: :test do
         chapter_2.save!
 
         book.description = '#foo'
-        book.rebuild!([chapter_1, chapter_2])
+        book.rebuild_chapters!([chapter_1, chapter_2])
 
-        chapter_1.rebuild!([lesson_1, lesson_2])
-        chapter_2.rebuild!([lesson_3])
+        chapter_1.rebuild_lessons!([lesson_1, lesson_2])
+        chapter_2.rebuild_lessons!([lesson_3])
       end
 
       it "rebuilds successfully" do
@@ -155,11 +155,11 @@ describe Book, organization_workspace: :test do
 
     context 'when chapter is rebuilt before book rebuilt' do
       before do
-        chapter_1.rebuild!([lesson_1, lesson_2])
-        chapter_2.rebuild!([lesson_3])
+        chapter_1.rebuild_lessons!([lesson_1, lesson_2])
+        chapter_2.rebuild_lessons!([lesson_3])
 
         book.description = '#foo'
-        book.rebuild!([chapter_1, chapter_2])
+        book.rebuild_chapters!([chapter_1, chapter_2])
       end
 
       it "rebuilds successfully" do

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -174,5 +174,20 @@ describe Book, organization_workspace: :test do
         expect(chapter_2.guides).to eq [guide_3]
       end
     end
+
+    context 'when rebuilt content changes' do
+      before { book.rebuild_chapters!([chapter_1, chapter_2]) }
+
+      let!(:usage_1) { Usage.find_by parent_item: chapter_1 }
+      let!(:usage_2) { Usage.find_by parent_item: chapter_2 }
+
+      before { book.rebuild_chapters!([chapter_2]) }
+
+      it { expect { chapter_1.reload }.to raise_error ActiveRecord::RecordNotFound }
+      it { expect { chapter_2.reload }.to_not raise_error }
+      it { expect { usage_1.reload }.to raise_error ActiveRecord::RecordNotFound }
+      it { expect { usage_2.reload }.to_not raise_error }
+      it { expect(Chapter.count).to eq 1 }
+    end
   end
 end


### PR DESCRIPTION
Modifying usage indexation to rebuild only the necessary parts.

This should hopefully improve this process' performance a little, and we're planning on taking advantage of this on #61. 