### PR TITLE
Fix orphan usages

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -4,6 +4,7 @@ class Book < Content
   aggregate_of :complements
 
   has_many :chapters, -> { order(number: :asc) }, dependent: :destroy
+  has_many :topics, through: :chapters
   has_many :complements, dependent: :destroy
 
   has_many :exercises, through: :chapters
@@ -11,6 +12,8 @@ class Book < Content
   organic_on :discussions
 
   delegate :first_lesson, to: :first_chapter
+
+  alias_method :children, :topics
 
   def to_s
     slug

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -19,6 +19,8 @@ class Guide < Content
 
   enum type: [:learning, :practice]
 
+  alias_method :children, :exercises
+
   def clear_progress!(user, organization=Organization.current)
     transaction do
       exercises.each do |exercise|

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -9,6 +9,8 @@ class Topic < Content
 
   markdown_on :appendix
 
+  alias_method :children, :guides
+
   def pending_lessons(user)
     guides.
         joins('left join public.exercises exercises

--- a/app/models/usage.rb
+++ b/app/models/usage.rb
@@ -7,9 +7,18 @@ class Usage < ApplicationRecord
   scope :in_organization, ->(organization = Organization.current) { where(organization_id: organization.id) }
 
   before_save :set_slug
+  before_destroy :destroy_children_usages!
+
+  def self.destroy_all_where(query)
+    where(query).destroy_all
+  end
 
   def self.destroy_usages_for(record)
-    Usage.where(parent_item: record).destroy_all
+    destroy_all_where(parent_item: record)
+  end
+
+  def destroy_children_usages!
+    item.children.each { |child| Usage.destroy_all_where(item: child, organization: organization) }
   end
 
   def index_children!(children)

--- a/lib/mumuki/domain/factories/exercise_factory.rb
+++ b/lib/mumuki/domain/factories/exercise_factory.rb
@@ -65,6 +65,10 @@ FactoryBot.define do
 
   factory :exercise, parent: :problem
 
+  factory :indexed_exercise, parent: :exercise do
+    guide { create(:indexed_guide) }
+  end
+
   factory :x_equal_5_exercise, parent: :exercise do
     test { 'describe "x" $ do
              it "should be equal 5" $ do

--- a/lib/mumuki/domain/factories/guide_factory.rb
+++ b/lib/mumuki/domain/factories/guide_factory.rb
@@ -27,4 +27,11 @@ FactoryBot.define do
     end
   end
 
+  factory :indexed_guide, parent: :guide do
+    after(:build) do |guide|
+      create(:lesson, guide: guide, topic: create(:indexed_topic))
+
+      reindex_current_organization!
+    end
+  end
 end

--- a/lib/mumuki/domain/factories/topic_factory.rb
+++ b/lib/mumuki/domain/factories/topic_factory.rb
@@ -6,4 +6,10 @@ FactoryBot.define do
     slug { "mumuki/mumuki-sample-topic-#{SecureRandom.uuid}" }
     locale { :en }
   end
+
+  factory :indexed_topic, parent: :topic do
+    after(:build) do |topic|
+      create(:chapter, topic: topic)
+    end
+  end
 end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -176,17 +176,27 @@ describe Book, organization_workspace: :test do
     end
 
     context 'when rebuilt content changes' do
+      let(:guide_1) { create :indexed_guide }
+      let(:guide_2) { create :indexed_guide }
+
+      let(:chapter_1) { guide_1.chapter }
+      let(:chapter_2) { guide_2.chapter }
+
       before { book.rebuild_chapters!([chapter_1, chapter_2]) }
 
-      let!(:usage_1) { Usage.find_by parent_item: chapter_1 }
-      let!(:usage_2) { Usage.find_by parent_item: chapter_2 }
+      let!(:chapter_1_usage) { Usage.find_by parent_item: chapter_1 }
+      let!(:chapter_2_usage) { Usage.find_by parent_item: chapter_2 }
+      let!(:guide_1_usage) { Usage.find_by item: guide_1 }
+      let!(:guide_2_usage) { Usage.find_by item: guide_2 }
 
       before { book.rebuild_chapters!([chapter_2]) }
 
       it { expect { chapter_1.reload }.to raise_error ActiveRecord::RecordNotFound }
       it { expect { chapter_2.reload }.to_not raise_error }
-      it { expect { usage_1.reload }.to raise_error ActiveRecord::RecordNotFound }
-      it { expect { usage_2.reload }.to_not raise_error }
+      it { expect { chapter_1_usage.reload }.to raise_error ActiveRecord::RecordNotFound }
+      it { expect { chapter_2_usage.reload }.to_not raise_error }
+      it { expect { guide_1_usage.reload }.to raise_error ActiveRecord::RecordNotFound }
+      it { expect { guide_2_usage.reload }.to_not raise_error }
       it { expect(Chapter.count).to eq 1 }
     end
   end


### PR DESCRIPTION
While testing #62 I realised we were leaving some orphan usages when removing a chapter from a book, since the chapter's usages were being destroyed, but not the chapter's lessons.

This doesn't seem like an ideal solution but a quick test seems to show that this is still _way_ better than destroying and recreating the whole usage tree.