### PR TITLE
Chore assignments save

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -205,11 +205,6 @@ class Assignment < Progress
     exercise.files_for(current_content)
   end
 
-  def save!(*)
-    self.organization = Organization.current
-    super
-  end
-
   private
 
   def update_submissions_count!

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -41,6 +41,12 @@ class Assignment < Progress
   alias_method :completed?, :passed?
 
   after_save :dirty_parent_by_submission!, if: :completion_changed?
+  before_save :set_current_organization, unless: :organization
+
+  # TODO: Momentary as some assignments may not have an associated organization
+  def set_current_organization
+    self.organization = Organization.current
+  end
 
   def completion_changed?
     completed_before_last_save? != completed?

--- a/lib/mumuki/domain/submission/base.rb
+++ b/lib/mumuki/domain/submission/base.rb
@@ -41,6 +41,7 @@ class Mumuki::Domain::Submission::Base
 
   def save_submission!(assignment)
     assignment.content = content
+    assignment.organization = Organization.current
     assignment.save!
   end
 


### PR DESCRIPTION
It:

- adds more tests to verify organization is properly set in assignment
- changes save! override for a callback
- changes the organization on submission

This prevents from setting an incorrect organization when updating the assignment.

The callback can be removed when all the assignments have an organization.
The line in `save_submission!` can be removed once we activate the separation of progress.