### PR TITLE
Uniq expectation results

### DIFF
--- a/app/models/concerns/contextualization.rb
+++ b/app/models/concerns/contextualization.rb
@@ -64,7 +64,7 @@ module Contextualization
   end
 
   def failed_expectation_results
-    expectation_results.to_a.select { |it| it[:result].failed? }
+    expectation_results.to_a.select { |it| it[:result].failed? }.uniq
   end
 
   def expectation_results_visible?


### PR DESCRIPTION
Prevent expectation results showing twice or more for cases where implicit expectations are auto generated such as here:

![image](https://user-images.githubusercontent.com/11720274/80115944-bd241c80-855b-11ea-99d7-b149c9a06191.png)
