### PR TITLE
Feature affable methods

### DIFF
--- a/app/models/concerns/contextualization.rb
+++ b/app/models/concerns/contextualization.rb
@@ -98,6 +98,7 @@ module Contextualization
   end
 
   def humanized_expectation_results
+    warn "Don't use humanized_expectation_results. Use affable_expectation_results, which also handles markdown an sanitization"
     visible_expectation_results.map do |it|
       {
         result: it[:result],

--- a/app/models/concerns/contextualization.rb
+++ b/app/models/concerns/contextualization.rb
@@ -107,7 +107,6 @@ module Contextualization
     end
   end
 
-
   ####################
   ## Affable results
   ####################
@@ -127,12 +126,12 @@ module Contextualization
 
   def affable_test_results
     test_results.map do |it|
-      {
-        title: test_result[:title].affable,
-        result: test_result[:result].sanitized,
-        status: test_result[:status],
-        summary: test_result.dig(:summary, :message).affable
-      }
+      { summary: it.dig(:summary, :message).affable }
+        .compact
+        .merge(
+          title: it[:title].affable,
+          result: it[:result].sanitized,
+          status: it[:status])
     end
   end
 end

--- a/app/models/concerns/contextualization.rb
+++ b/app/models/concerns/contextualization.rb
@@ -105,4 +105,33 @@ module Contextualization
       }
     end
   end
+
+
+  ####################
+  ## Affable results
+  ####################
+
+  def affable_expectation_results
+    visible_expectation_results.map do |it|
+      {
+        result: it[:result],
+        explanation: Mulang::Expectation.parse(it).translate(inspection_keywords).affable
+      }
+    end
+  end
+
+  def affable_tips
+    tips.map(&:affable)
+  end
+
+  def affable_test_results
+    test_results.map do |it|
+      {
+        title: test_result[:title].affable,
+        result: test_result[:result].sanitized,
+        status: test_result[:status],
+        summary: test_result.dig(:summary, :message).affable
+      }
+    end
+  end
 end

--- a/app/models/concerns/contextualization.rb
+++ b/app/models/concerns/contextualization.rb
@@ -98,7 +98,7 @@ module Contextualization
   end
 
   def humanized_expectation_results
-    warn "Don't use humanized_expectation_results. Use affable_expectation_results, which also handles markdown an sanitization"
+    warn "Don't use humanized_expectation_results. Use affable_expectation_results, which also handles markdown and sanitization"
     visible_expectation_results.map do |it|
       {
         result: it[:result],

--- a/app/models/concerns/contextualization.rb
+++ b/app/models/concerns/contextualization.rb
@@ -125,7 +125,7 @@ module Contextualization
   end
 
   def affable_test_results
-    test_results.map do |it|
+    test_results.to_a.map do |it|
       { summary: it.dig(:summary, :message).affable }
         .compact
         .merge(

--- a/app/models/concerns/with_editor.rb
+++ b/app/models/concerns/with_editor.rb
@@ -19,7 +19,7 @@ module WithEditor
       struct id: "content_choice_#{index}",
              index: index,
              value: choice,
-             text: Mumukit::ContentType::Markdown.to_html(choice_text(choice))
+             text: choice_text(choice).markdownified
     end
   end
 

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -166,7 +166,7 @@ class Exercise < ApplicationRecord
   end
 
   def description_context
-    Mumukit::ContentType::Markdown.to_html splitted_description.first
+    splitted_description.first.markdownified
   end
 
   def splitted_description
@@ -174,7 +174,7 @@ class Exercise < ApplicationRecord
   end
 
   def description_task
-    Mumukit::ContentType::Markdown.to_html splitted_description.drop(1).join("\n")
+    splitted_description.drop(1).join("\n").markdownified
   end
 
   def custom?

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -132,7 +132,7 @@ class Exercise < ApplicationRecord
       .merge(settings: self[:settings])
       .merge(RANDOMIZED_FIELDS.map { |it| [it, self[it]] }.to_h)
       .symbolize_keys
-      .tap { |it| it.markdownify!(:hint, :corollary, :description, :teacher_info) if options[:markdownified] }
+      .tap { |it| it.markdownified!(:hint, :corollary, :description, :teacher_info) if options[:markdownified] }
   end
 
   def reset!

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -104,7 +104,7 @@ class Guide < Content
       .merge(super)
       .merge(exercises: exercises.map { |it| it.to_resource_h(options) })
       .merge(language: language.to_embedded_resource_h)
-      .tap { |it| it.markdownify!(:corollary, :description, :teacher_info) if options[:markdownified] }
+      .tap { |it| it.markdownified!(:corollary, :description, :teacher_info) if options[:markdownified] }
   end
 
   def to_markdownified_resource_h

--- a/lib/mumuki/domain/extensions/hash.rb
+++ b/lib/mumuki/domain/extensions/hash.rb
@@ -5,7 +5,7 @@ class Hash
   end
 
   def markdownified!(*keys, **options)
-    keys.each { |it| self[it] = self[it].markdownified }
+    keys.each { |it| self[it] = self[it].markdownified(**options) }
   end
 
   def markdownified(*keys, **options)

--- a/lib/mumuki/domain/extensions/hash.rb
+++ b/lib/mumuki/domain/extensions/hash.rb
@@ -1,5 +1,14 @@
 class Hash
-  def markdownify!(*keys)
-    keys.each { |it| self[it] = Mumukit::ContentType::Markdown.to_html(self[it]) }
+  def markdownify!(*keys, **options)
+    warn "Don't use markdownify. Use markdownified! instead"
+    markdownified! *keys, **options
+  end
+
+  def markdownified!(*keys, **options)
+    keys.each { |it| self[it] = self[it].markdownified }
+  end
+
+  def markdownified(*keys, **options)
+    map { |k, v| key.in?(keys) ? v.markdownified(options) : v }.to_h
   end
 end

--- a/lib/mumuki/domain/extensions/string.rb
+++ b/lib/mumuki/domain/extensions/string.rb
@@ -27,3 +27,38 @@ class String
     File.extname(self).delete '.'
   end
 end
+
+
+# The nil-safe affable pipeline goes as follow:
+#
+# i18n > markdownified > sanitized > affable
+#
+# Where:
+#  * i18n: translates to current locale
+#  * markdownified: interpretes markdown in message and generates HTML
+#  * sanitized: sanitizes results HTML
+#  * affable: changes structure to hide low level details
+class String
+  def affable
+    markdownified(one_liner: true).sanitized
+  end
+
+  def markdownified(**options)
+    Mumukit::ContentType::Markdown.to_html self, options
+  end
+
+  def sanitized
+    Mumukit::ContentType::Sanitizer.sanitize self
+  end
+end
+
+class NilClass
+  def affable
+  end
+
+  def markdownified(**options)
+  end
+
+  def sanitized
+  end
+end

--- a/lib/mumuki/domain/extensions/string.rb
+++ b/lib/mumuki/domain/extensions/string.rb
@@ -38,15 +38,24 @@ end
 #  * markdownified: interpretes markdown in message and generates HTML
 #  * sanitized: sanitizes results HTML
 #  * affable: changes structure to hide low level details
+#
+# Other classes may polymorphically implement they own
+# markdownified, sanitized and affable methods with similar semantics
+# to extend this pipeline to non-strings
 class String
+
+  # Creates a humman representation - but not necessary UI - representation
+  # of this strings by interpreting its markdown as a one-liner and sanitizing it
   def affable
     markdownified(one_liner: true).sanitized
   end
 
+  # Interprets the markdown on this string, and converts it into HTML
   def markdownified(**options)
     Mumukit::ContentType::Markdown.to_html self, options
   end
 
+  # Sanitizes this string, escaping unsafe HTML sequences
   def sanitized
     Mumukit::ContentType::Sanitizer.sanitize self
   end

--- a/lib/mumuki/domain/extensions/string.rb
+++ b/lib/mumuki/domain/extensions/string.rb
@@ -39,13 +39,13 @@ end
 #  * sanitized: sanitizes results HTML
 #  * affable: changes structure to hide low level details
 #
-# Other classes may polymorphically implement they own
+# Other classes may polymorphically implement their own
 # markdownified, sanitized and affable methods with similar semantics
 # to extend this pipeline to non-strings
 class String
 
   # Creates a humman representation - but not necessary UI - representation
-  # of this strings by interpreting its markdown as a one-liner and sanitizing it
+  # of this string by interpreting its markdown as a one-liner and sanitizing it
   def affable
     markdownified(one_liner: true).sanitized
   end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -286,6 +286,29 @@ describe Assignment, organization_workspace: :test do
     end
   end
 
+  describe '#affable_tips' do
+    let(:exercise) { create(:exercise, assistance_rules: assistance_rules) }
+    let(:assignment) { create(:assignment, exercise: exercise, solution: '') }
+
+    context 'plain explanation' do
+      let(:assistance_rules) { [{when: 'content_empty', then: 'oops, please write something in the editor'}] }
+
+      it { expect(assignment.affable_tips.first).to include 'please write something in the editor'  }
+    end
+
+    context 'html explanation' do
+      let(:assistance_rules) { [{when: 'content_empty', then: 'oops, please write <strong>something</strong> in the editor'}] }
+
+      it { expect(assignment.affable_tips.first).to include 'please write <strong>something</strong> in the editor'  }
+    end
+
+    context 'markdown explanation' do
+      let(:assistance_rules) { [{when: 'content_empty', then: 'oops, please write **something** in the editor'}] }
+
+      it { expect(assignment.affable_tips.first).to include 'please write <strong>something</strong> in the editor'  }
+    end
+  end
+
   describe '#affable_test_results' do
     let(:assignment) { create(:assignment, test_results: test_results) }
 

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -268,6 +268,11 @@ describe Assignment, organization_workspace: :test do
     let(:assignment) { create(:assignment, expectation_results: expectation_results) }
 
     context 'plain explanation' do
+      let(:expectation_results) { nil }
+      it { expect(assignment.affable_expectation_results).to be_empty  }
+    end
+
+    context 'plain explanation' do
       let(:expectation_results) { [{result: :failed, binding: '<<custom>>', inspection: 'foo uses composition'}] }
 
       it { expect(assignment.affable_expectation_results).to eq [{result: :failed, explanation: 'foo uses composition'}]  }
@@ -290,6 +295,12 @@ describe Assignment, organization_workspace: :test do
     let(:exercise) { create(:exercise, assistance_rules: assistance_rules) }
     let(:assignment) { create(:assignment, exercise: exercise, solution: '') }
 
+
+    context 'no assistance rules' do
+      let(:assistance_rules) { nil }
+      it { expect(assignment.affable_tips).to be_empty  }
+    end
+
     context 'plain explanation' do
       let(:assistance_rules) { [{when: 'content_empty', then: 'oops, please write something in the editor'}] }
 
@@ -311,6 +322,12 @@ describe Assignment, organization_workspace: :test do
 
   describe '#affable_test_results' do
     let(:assignment) { create(:assignment, test_results: test_results) }
+
+    context 'no results' do
+      let(:test_results) { nil }
+      it { expect(assignment.affable_test_results).to be_empty  }
+    end
+
 
     context 'plain title or summary' do
       let(:test_results) do

--- a/spec/models/hash_spec.rb
+++ b/spec/models/hash_spec.rb
@@ -4,7 +4,7 @@ describe Hash do
   describe 'markdown_paragraphs' do
     let(:hash) { { something: 'hello **world**', something_else: '`the code`', other: '_foo_' } }
 
-    before { hash.markdownify! :something, :something_else }
+    before { hash.markdownified! :something, :something_else }
 
     it { expect(hash).to eq other: "_foo_", something: "<p>hello <strong>world</strong></p>\n", something_else: "<p><code>the code</code></p>\n" }
   end

--- a/spec/models/hash_spec.rb
+++ b/spec/models/hash_spec.rb
@@ -1,11 +1,17 @@
 require 'spec_helper'
 
 describe Hash do
-  describe 'markdown_paragraphs' do
+  describe 'markdownified!' do
     let(:hash) { { something: 'hello **world**', something_else: '`the code`', other: '_foo_' } }
 
-    before { hash.markdownified! :something, :something_else }
+    context 'without options' do
+      before { hash.markdownified! :something, :something_else }
+      it { expect(hash).to eq other: "_foo_", something: "<p>hello <strong>world</strong></p>\n", something_else: "<p><code>the code</code></p>\n" }
+    end
 
-    it { expect(hash).to eq other: "_foo_", something: "<p>hello <strong>world</strong></p>\n", something_else: "<p><code>the code</code></p>\n" }
+    context 'with options' do
+      before { hash.markdownified! :something, :something_else, one_liner: true }
+      it { expect(hash).to eq other: "_foo_", something: "hello <strong>world</strong>", something_else: "<code>the code</code>" }
+    end
   end
 end


### PR DESCRIPTION
### :dart: PR Goal

This PR introduces the new general concept of `affable`, and provides implementations for strings and `nil`. 

Affable is modeled thinking of the `humanized` concept of rails, but... with a different name (:stuck_out_tongue: ) and semantics: it is abut converting things with markdown into santized, html-compatible things. 

`affable` concept thus reifies some previously methods known as `*_html` or `humanized_*`, and introduces the concept of a 'htmelization' pipeline: 

1. translate
2. `markdownified` convert into markdown
3.  `sanitized`: convert the object into one with identical structure, but sanitized content
4. `affable`: hide low level details in the structure, changing it if necessary
5. convert into html 

The two first steps are domain-level operations, but the latter is UI-specific, so it is outside this PR. 

Those methods may be implemented in any kind of objects or attributes. In strings they are implemented so that `affable` is just `markdownified` + `sanitized`. Implementation is nil-safe. 

## :back: Backward compatibility

This PR is fully backward compatible - aside of some deprecation warnings. It should be introduced in a minor release

## :memo:  Additional notes

I made markdown conversion names a bit more consistent - still, the `markdown_on` produces methods like `*_html` instead of `markdownified_*`, that may be refactored in the future - and added missing tests. Also, this is the first code in domain that explicitly uses `summary` field from bridge. 

### :eyes: Relations

 * Related to https://github.com/mumuki/mumukit-assistant/pull/7 - because I had problems testing this feature
* Related to https://github.com/mumuki/mumuki-laboratory/pull/1400 - because I am using this features in it
