### PR TITLE
Chore avatar in resource hash

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User < ApplicationRecord
   before_validation :set_uid!
   validates :uid, presence: true
 
-  resource_fields :uid, :social_id, :profile_picture, :email, :permissions, :verified_first_name, :verified_last_name, *profile_fields
+  resource_fields :uid, :social_id, :email, :permissions, :verified_first_name, :verified_last_name, *profile_fields
 
   def last_lesson
     last_guide.try(:lesson)
@@ -107,6 +107,10 @@ class User < ApplicationRecord
     update! self.class.slice_resource_h json
   end
 
+  def to_resource_h
+    super.merge(image_url: profile_picture)
+  end
+
   def verify_name!
     self.verified_first_name ||= first_name
     self.verified_last_name ||= last_name
@@ -153,7 +157,7 @@ class User < ApplicationRecord
   def init
     # Temporarily keep using image_url until avatars are created
     # self.avatar = Avatar.sample unless profile_picture.present?
-    
+
     self.image_url ||= "user_shape.png"
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -151,7 +151,10 @@ class User < ApplicationRecord
   end
 
   def init
-    self.avatar = Avatar.sample unless profile_picture.present?
+    # Temporarily keep using image_url until avatars are created
+    # self.avatar = Avatar.sample unless profile_picture.present?
+    
+    self.image_url ||= "user_shape.png"
   end
 
   def self.sync_key_id_field

--- a/spec/lib/user_helpers_spec.rb
+++ b/spec/lib/user_helpers_spec.rb
@@ -45,7 +45,7 @@ describe Mumuki::Domain::Helpers::User do
       it { expect(user.to_resource_h)
                .to json_eq(
                        uid: json[:uid],
-                       profile_picture: json[:image_url],
+                       image_url: json[:image_url],
                        email: json[:email],
                        first_name: json[:first_name],
                        last_name: json[:last_name],
@@ -62,7 +62,7 @@ describe Mumuki::Domain::Helpers::User do
       it { expect(user.to_resource_h)
                .to json_eq(
                        uid: json[:uid],
-                       profile_picture: avatar.image_url,
+                       image_url: avatar.image_url,
                        email: json[:email],
                        first_name: json[:first_name],
                        last_name: json[:last_name],


### PR DESCRIPTION
I changed the user resource hash _a little too much_ in https://github.com/mumuki/mumuki-domain/pull/84, which would inadvertently break/cause inconsistencies between labo/academia and classroom. (inadvertently to me :stuck_out_tongue_closed_eyes:)

Additionally, it temporarily rollbacks setting avatars to new users so we can safely deploy at this intermediate stage in which the avatars are still to be decided on, drawn and added.

Closes https://github.com/mumuki/ikumi-online/issues/625

Just merge if it's okay