### PR TITLE
Fix factory warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :test do
   gem 'rspec-rails', '~> 3.6'
   gem 'factory_bot_rails'
   gem 'rake', '~> 12.3'
-  gem 'faker', '~> 1.5'
+  gem 'faker', '~> 2.2'
 end
 
 gem 'codeclimate-test-reporter', :group => :test, :require => nil

--- a/lib/mumuki/domain/factories/book_factory.rb
+++ b/lib/mumuki/domain/factories/book_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :book do
-    name { Faker::Lorem.sentence(3) }
-    description { Faker::Lorem.sentence(30) }
+    name { Faker::Lorem.sentence(word_count: 3) }
+    description { Faker::Lorem.sentence(word_count: 30) }
     slug { "mumuki/mumuki-test-book-#{SecureRandom.uuid}" }
   end
 end

--- a/lib/mumuki/domain/factories/chapter_factory.rb
+++ b/lib/mumuki/domain/factories/chapter_factory.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
 
   factory :chapter do
-    number { Faker::Number.between(1, 40) }
+    number { Faker::Number.between(from: 1, to: 40) }
     book { Organization.current.book rescue nil }
 
     transient do
       lessons { [] }
-      name { Faker::Lorem.sentence(3) }
+      name { Faker::Lorem.sentence(word_count: 3) }
       slug { "mumuki/mumuki-test-topic-#{SecureRandom.uuid}" }
     end
 

--- a/lib/mumuki/domain/factories/exam_factory.rb
+++ b/lib/mumuki/domain/factories/exam_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
 
   factory :exam, traits: [:guide_container] do
-    duration { Faker::Number.between(10, 60).minutes }
+    duration { Faker::Number.between(from: 10, to:60).minutes }
     organization { Organization.current }
     start_time { 5.minutes.ago }
     end_time { 10.minutes.since }

--- a/lib/mumuki/domain/factories/guide_factory.rb
+++ b/lib/mumuki/domain/factories/guide_factory.rb
@@ -11,8 +11,8 @@ FactoryBot.define do
   trait :guide_container do
     transient do
       exercises { [] }
-      name { Faker::Lorem.sentence(3) }
-      description { Faker::Lorem.sentence(10) }
+      name { Faker::Lorem.sentence(word_count: 3) }
+      description { Faker::Lorem.sentence(word_count: 10) }
       language { create(:language) }
       slug { "mumuki/mumuki-test-lesson-#{SecureRandom.uuid}" }
     end

--- a/lib/mumuki/domain/factories/invitation_factory.rb
+++ b/lib/mumuki/domain/factories/invitation_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :invitation do
-    code { Faker::Lorem.sentence(6) }
+    code { Faker::Lorem.sentence(word_count: 6) }
     course { "foo/bar" }
     expiration_date { 5.minutes.since }
   end

--- a/lib/mumuki/domain/factories/topic_factory.rb
+++ b/lib/mumuki/domain/factories/topic_factory.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
 
   factory :topic do
-    name { Faker::Lorem::sentence(3) }
-    description { Faker::Lorem.paragraph(2) }
+    name { Faker::Lorem::sentence(word_count: 3) }
+    description { Faker::Lorem.paragraph(sentence_count: 2) }
     slug { "mumuki/mumuki-sample-topic-#{SecureRandom.uuid}" }
     locale { :en }
   end

--- a/mumuki-domain.gemspec
+++ b/mumuki-domain.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'mumukit-auth', '~> 7.6'
   s.add_dependency 'mumukit-assistant', '~> 0.2'
-  s.add_dependency 'mumukit-bridge', '~> 4.0'
+  s.add_dependency 'mumukit-bridge', '~> 4.1'
   s.add_dependency 'mumukit-content-type', '~> 1.7'
   s.add_dependency 'mumukit-core', '~> 1.13'
   s.add_dependency 'mumukit-directives', '~> 0.5'


### PR DESCRIPTION
Academia is conflicting due to Labo having the latest Bridge version while Domain is behind.

Also, since Academia wasn't locked to a specific Faker vesion, a million tests were throwing warnings about some named parameters on that gem. I updated Faker, fixed the warnings, and locked the current version in Academia so it doesn't happen again.