### PR TITLE
Feature experience points

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -40,6 +40,7 @@ class Assignment < Progress
   alias_method :parent_content, :guide
   alias_method :user, :submitter
 
+  before_save :award_experience_points!, :update_top_submission!, if: :submission_status_changed?
   after_save :dirty_parent_by_submission!, if: :completion_changed?
   before_validation :set_current_organization!, unless: :organization
 
@@ -227,7 +228,7 @@ class Assignment < Progress
   end
 
   def update_top_submission!
-    self.update! top_submission_status: submission_status unless submission_status.improved_by?(top_submission_status)
+    self.top_submission_status = submission_status unless submission_status.improved_by?(top_submission_status)
   end
 
   private

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -160,7 +160,10 @@ class Assignment < Progress
   end
 
   def to_resource_h
-    as_json(except: %i(exercise_id submission_id organization_id id submitter_id solution created_at updated_at submission_status submitted_at parent_id),
+    excluded_fields = %i(created_at exercise_id id organization_id parent_id solution submission_id
+                         submission_status submitted_at submitter_id top_submission_status updated_at)
+
+    as_json(except: excluded_fields,
               include: {
                 guide: {
                   only: [:slug, :name],

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -226,6 +226,10 @@ class Assignment < Progress
     exercise.files_for(current_content)
   end
 
+  def update_top_submission!
+    self.update! top_submission_status: submission_status unless submission_status.improved_by?(top_submission_status)
+  end
+
   private
 
   def update_submissions_count!

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,6 +1,7 @@
 class Assignment < Progress
   include Contextualization
   include WithMessages
+  include Gamified
 
   markdown_on :extra_preview
 

--- a/app/models/concerns/contextualization.rb
+++ b/app/models/concerns/contextualization.rb
@@ -16,6 +16,7 @@ module Contextualization
   end
 
   included do
+    serialize :top_submission_status, Mumuki::Domain::Status::Submission
     serialize :submission_status, Mumuki::Domain::Status::Submission
     validates_presence_of :submission_status
 

--- a/app/models/concerns/gamified.rb
+++ b/app/models/concerns/gamified.rb
@@ -1,0 +1,11 @@
+module Gamified
+  def award_experience_points!
+    stats = user_stats_for(submitter, organization)
+    stats.exp += submission_status.exp_given
+    stats.save!
+  end
+
+  def user_stats_for(user, organization)
+    UserStats.find_or_initialize_by(user: user, organization: organization)
+  end
+end

--- a/app/models/concerns/gamified.rb
+++ b/app/models/concerns/gamified.rb
@@ -1,8 +1,16 @@
 module Gamified
   def award_experience_points!
-    stats = user_stats_for(submitter, organization)
-    stats.exp += submission_status.exp_given
-    stats.save!
+    points = net_experience
+
+    if points > 0
+      stats = user_stats_for(submitter, organization)
+      stats.add_exp!(points)
+      stats.save!
+    end
+  end
+
+  def net_experience
+    submission_status.exp_given - top_submission_status.exp_given
   end
 
   def user_stats_for(user, organization)

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -1,0 +1,5 @@
+class UserStats < ApplicationRecord
+  belongs_to :organization
+  belongs_to :user
+
+end

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -2,4 +2,7 @@ class UserStats < ApplicationRecord
   belongs_to :organization
   belongs_to :user
 
+  def add_exp!(points)
+    self.exp += points
+  end
 end

--- a/db/migrate/20200616160640_create_user_stats.rb
+++ b/db/migrate/20200616160640_create_user_stats.rb
@@ -1,0 +1,10 @@
+class CreateUserStats < ActiveRecord::Migration[5.1]
+  def change
+    create_table :user_stats do |t|
+      t.integer :exp, default: 0
+
+      t.references :user, index: true
+      t.references :organization, index: true
+    end
+  end
+end

--- a/db/migrate/20200617142217_add_top_submission_status_to_assignments.rb
+++ b/db/migrate/20200617142217_add_top_submission_status_to_assignments.rb
@@ -1,0 +1,5 @@
+class AddTopSubmissionStatusToAssignments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :assignments, :top_submission_status, :integer, default: 0
+  end
+end

--- a/lib/mumuki/domain/status/submission/passed.rb
+++ b/lib/mumuki/domain/status/submission/passed.rb
@@ -8,4 +8,8 @@ module Mumuki::Domain::Status::Submission::Passed
   def self.iconize
     {class: :success, type: 'check-circle'}
   end
+
+  def self.exp_given
+    100
+  end
 end

--- a/lib/mumuki/domain/status/submission/passed_with_warnings.rb
+++ b/lib/mumuki/domain/status/submission/passed_with_warnings.rb
@@ -12,4 +12,8 @@ module Mumuki::Domain::Status::Submission::PassedWithWarnings
   def self.iconize
     {class: :warning, type: 'exclamation-circle'}
   end
+
+  def self.exp_given
+    50
+  end
 end

--- a/lib/mumuki/domain/status/submission/skipped.rb
+++ b/lib/mumuki/domain/status/submission/skipped.rb
@@ -8,4 +8,8 @@ module Mumuki::Domain::Status::Submission::Skipped
   def self.iconize
     {class: :success, type: 'check-circle'}
   end
+
+  def self.exp_given
+    100
+  end
 end

--- a/lib/mumuki/domain/status/submission/submission.rb
+++ b/lib/mumuki/domain/status/submission/submission.rb
@@ -43,6 +43,10 @@ module Mumuki::Domain::Status::Submission
     passed? || skipped?
   end
 
+  def improved_by?(status)
+    self.exp_given < status.exp_given
+  end
+
   def exp_given
     0
   end

--- a/lib/mumuki/domain/status/submission/submission.rb
+++ b/lib/mumuki/domain/status/submission/submission.rb
@@ -42,4 +42,8 @@ module Mumuki::Domain::Status::Submission
   def solved?
     passed? || skipped?
   end
+
+  def exp_given
+    0
+  end
 end

--- a/lib/mumuki/domain/submission/base.rb
+++ b/lib/mumuki/domain/submission/base.rb
@@ -48,8 +48,6 @@ class Mumuki::Domain::Submission::Base
   def save_results!(results, assignment)
     assignment.assign_attributes results
     assignment.increment_attempts!
-    assignment.award_experience_points!
-    assignment.update_top_submission!
     assignment.save! results
   end
 

--- a/lib/mumuki/domain/submission/base.rb
+++ b/lib/mumuki/domain/submission/base.rb
@@ -48,6 +48,7 @@ class Mumuki::Domain::Submission::Base
   def save_results!(results, assignment)
     assignment.assign_attributes results
     assignment.increment_attempts!
+    assignment.award_experience_points!
     assignment.save! results
   end
 

--- a/lib/mumuki/domain/submission/base.rb
+++ b/lib/mumuki/domain/submission/base.rb
@@ -49,6 +49,7 @@ class Mumuki::Domain::Submission::Base
     assignment.assign_attributes results
     assignment.increment_attempts!
     assignment.award_experience_points!
+    assignment.update_top_submission!
     assignment.save! results
   end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200608132959) do
+ActiveRecord::Schema.define(version: 20200616160640) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -351,6 +351,14 @@ ActiveRecord::Schema.define(version: 20200608132959) do
     t.index ["item_type", "item_id"], name: "index_usages_on_item_type_and_item_id"
     t.index ["organization_id"], name: "index_usages_on_organization_id"
     t.index ["parent_item_type", "parent_item_id"], name: "index_usages_on_parent_item_type_and_parent_item_id"
+  end
+
+  create_table "user_stats", force: :cascade do |t|
+    t.integer "exp", default: 0
+    t.bigint "user_id"
+    t.bigint "organization_id"
+    t.index ["organization_id"], name: "index_user_stats_on_organization_id"
+    t.index ["user_id"], name: "index_user_stats_on_user_id"
   end
 
   create_table "users", id: :serial, force: :cascade do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200616160640) do
+ActiveRecord::Schema.define(version: 20200617142217) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20200616160640) do
     t.bigint "organization_id"
     t.datetime "submitted_at"
     t.bigint "parent_id"
+    t.integer "top_submission_status", default: 0
     t.index ["exercise_id"], name: "index_assignments_on_exercise_id"
     t.index ["organization_id"], name: "index_assignments_on_organization_id"
     t.index ["parent_id"], name: "index_assignments_on_parent_id"

--- a/spec/models/gamified_spec.rb
+++ b/spec/models/gamified_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+describe Gamified, organization_workspace: :test do
+
+  def award_experience_points!(assignment, status)
+    assignment.status = status
+    assignment.award_experience_points!
+    assignment.update_top_submission!
+  end
+
+  let(:student) { create(:user) }
+  let(:exercise) { create(:indexed_exercise) }
+  let(:assignment) { create(:assignment, submitter: student, exercise: exercise)}
+  let(:experience_points) { assignment.user_stats_for(student, Organization.current) }
+
+  describe '#award_experience_points!' do
+    context 'no passed exercises' do
+      it 'has no experience points for that user' do
+        expect(experience_points.exp).to eq 0
+      end
+    end
+
+    context 'one passed exercise' do
+      it 'does not award points for a failed exercise' do
+        award_experience_points!(assignment, :failed)
+
+        expect(experience_points.exp).to eq 0
+      end
+
+      it 'awards points for a passed with warnings exercise' do
+        award_experience_points!(assignment, :passed_with_warnings)
+
+        expect(experience_points.exp).to eq Mumuki::Domain::Status::Submission::PassedWithWarnings.exp_given
+      end
+
+      it 'awards points for a passed exercise' do
+        award_experience_points!(assignment, :passed)
+
+        expect(experience_points.exp).to eq Mumuki::Domain::Status::Submission::Passed.exp_given
+      end
+
+      it 'awards max points once even if passed multiple times' do
+        award_experience_points!(assignment, :passed)
+        award_experience_points!(assignment, :passed)
+        award_experience_points!(assignment, :passed)
+
+        expect(experience_points.exp).to eq Mumuki::Domain::Status::Submission::Passed.exp_given
+      end
+
+      it 'awards max points once even if gradually improved' do
+        award_experience_points!(assignment, :failed)
+        award_experience_points!(assignment, :passed_with_warnings)
+        award_experience_points!(assignment, :passed)
+
+        expect(experience_points.exp).to eq Mumuki::Domain::Status::Submission::Passed.exp_given
+      end
+
+      it 'does not take points away even if failed after passing' do
+        award_experience_points!(assignment, :passed)
+        award_experience_points!(assignment, :failed)
+
+        expect(experience_points.exp).to eq Mumuki::Domain::Status::Submission::Passed.exp_given
+      end
+
+      it 'does not take points away even if errored after passing with warnings' do
+        award_experience_points!(assignment, :passed_with_warnings)
+        award_experience_points!(assignment, :errored)
+
+        expect(experience_points.exp).to eq Mumuki::Domain::Status::Submission::PassedWithWarnings.exp_given
+      end
+    end
+
+    context 'many passed exercises' do
+      let(:another_exercise) { create(:indexed_exercise) }
+      let(:another_assignment) { create(:assignment, submitter: student, exercise: exercise)}
+      let(:one_more_exercise) { create(:indexed_exercise) }
+      let(:one_more_assignment) { create(:assignment, submitter: student, exercise: exercise)}
+
+      before do
+        award_experience_points!(assignment, :passed)
+        award_experience_points!(another_assignment, :passed)
+        award_experience_points!(one_more_assignment, :passed)
+      end
+
+      it 'adds up experience' do
+        expect(experience_points.exp).to eq Mumuki::Domain::Status::Submission::Passed.exp_given * 3
+      end
+    end
+  end
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe Mumuki::Domain::Status::Submission do
+  let(:submission) { Mumuki::Domain::Status::Submission }
+
+  let(:aborted)                   { submission::Aborted }
+  let(:errored)                   { submission::Errored }
+  let(:failed)                    { submission::Failed }
+  let(:manual_evaluation_pending) { submission::ManualEvaluationPending }
+  let(:passed)                    { submission::Passed }
+  let(:passed_with_warnings)      { submission::PassedWithWarnings }
+  let(:pending)                   { submission::Pending }
+  let(:running)                   { submission::Running }
+  let(:skipped)                   { submission::Skipped }
+
+  let(:statuses) { submission::STATUSES }
+  let(:exp_statuses) { [passed, passed_with_warnings, skipped] }
+  let(:no_exp_statuses) { statuses - exp_statuses }
+
+  describe 'aborted' do
+    it { expect(aborted.exp_given).to be 0 }
+    it { expect(   exp_statuses.all? { |status| aborted.improved_by?(status) }).to be true  }
+    it { expect(no_exp_statuses.all? { |status| aborted.improved_by?(status) }).to be false }
+  end
+
+  describe 'errored' do
+    it { expect(errored.exp_given).to be 0 }
+    it { expect(   exp_statuses.all? { |status| errored.improved_by?(status) }).to be true  }
+    it { expect(no_exp_statuses.all? { |status| errored.improved_by?(status) }).to be false }
+  end
+
+  describe 'failed' do
+    it { expect(failed.exp_given).to be 0 }
+    it { expect(   exp_statuses.all? { |status| failed.improved_by?(status) }).to be true  }
+    it { expect(no_exp_statuses.all? { |status| failed.improved_by?(status) }).to be false }
+  end
+
+  describe 'manual_evaluation_pending' do
+    it { expect(manual_evaluation_pending.exp_given).to be 0 }
+    it { expect(   exp_statuses.all? { |status| manual_evaluation_pending.improved_by?(status) }).to be true  }
+    it { expect(no_exp_statuses.all? { |status| manual_evaluation_pending.improved_by?(status) }).to be false }
+  end
+
+  describe 'passed' do
+    it { expect(passed.exp_given).to be 100 }
+    it { expect(statuses.all? { |status| passed.improved_by?(status) }).to be false }
+  end
+
+  describe 'passed_with_warnings' do
+    let(:solved_statuses) { exp_statuses - [passed_with_warnings] }
+
+    it { expect(passed_with_warnings.exp_given).to be 50 }
+    it { expect(solved_statuses.all? { |status| passed_with_warnings.improved_by?(status) }).to be true }
+    it { expect(no_exp_statuses.all? { |status| passed_with_warnings.improved_by?(status) }).to be false }
+  end
+
+  describe 'pending' do
+    it { expect(pending.exp_given).to be 0 }
+    it { expect(   exp_statuses.all? { |status| pending.improved_by?(status) }).to be true  }
+    it { expect(no_exp_statuses.all? { |status| pending.improved_by?(status) }).to be false }
+  end
+
+  describe 'running' do
+    it { expect(running.exp_given).to be 0 }
+    it { expect(   exp_statuses.all? { |status| running.improved_by?(status) }).to be true  }
+    it { expect(no_exp_statuses.all? { |status| running.improved_by?(status) }).to be false }
+  end
+
+  describe 'skipped' do
+    it { expect(skipped.exp_given).to be 100 }
+    it { expect(statuses.all? { |status| skipped.improved_by?(status) }).to be false }
+  end
+end


### PR DESCRIPTION
# :dart: Goal 

This PR awards experience points to users when an exercise is solved successfully.

# :memo: Details

Requires a new entity, called `ExperiencePoints`, which keeps track of how many exp points an user has on an organization.

100 points are awarded for passed exercises, while 50 are awarded for those passed with warnings. If an exercise passed with warnings is fixed, 50 more points are awarded - capping at 100 no matter how many tries it took or how they looked like.

This what-was-your-personal-best? on an exercise required adding a new field to assignments, called `top_submission_status`. It stores the best result ever on that assignment, whether it was passed with warnings, passed or skipped. A (positive) side effect of this is we won't award infinite points if an exercise is passed and then failed and then passed an indeterminate amount of times - it's just a matter of checking what the best result was.

# :question: Missing

~I'm writing tests.~ Done