### PR TITLE
Adding gamification_enabled? flag

### DIFF
--- a/lib/mumuki/domain/organization/settings.rb
+++ b/lib/mumuki/domain/organization/settings.rb
@@ -13,7 +13,8 @@ class Mumuki::Domain::Organization::Settings < Mumukit::Platform::Model
                       :forum_enabled?,
                       :report_issue_enabled?,
                       :disabled_from,
-                      :in_preparation_until
+                      :in_preparation_until,
+                      :gamification_enabled?
 
   def private?
     !public?

--- a/spec/lib/organization_helpers_spec.rb
+++ b/spec/lib/organization_helpers_spec.rb
@@ -22,6 +22,7 @@ describe Mumukit::Platform::Organization do
         forum_enabled: true,
         report_issue_enabled: true,
         public: false,
+        gamification_enabled: true,
         immersive: false,
         in_preparation_until: 1.minute.ago,
         disabled_from: 1.minute.ago,
@@ -93,6 +94,7 @@ describe Mumukit::Platform::Organization do
         it { expect(subject.forum_enabled?).to be true }
         it { expect(subject.feedback_suggestions_enabled?).to be true }
         it { expect(subject.public?).to eq false }
+        it { expect(subject.gamification_enabled?).to be true }
         it { expect(subject.embeddable?).to eq false }
         it { expect(subject.immersive?).to eq false }
         it { expect(subject.disabled?).to eq true }
@@ -111,6 +113,7 @@ describe Mumukit::Platform::Organization do
                             report_issue_enabled: false,
                             forum_enabled: false,
                             forum_discussions_minimal_role: 'teacher',
+                            gamification_enabled: false,
                             login_methods: [:google]) }
         let(:dump) { Mumuki::Domain::Organization::Settings.dump(settings) }
 
@@ -126,6 +129,7 @@ describe Mumukit::Platform::Organization do
         it { expect(subject.embeddable?).to eq true }
         it { expect(subject.immersive?).to eq true }
         it { expect(subject.disabled?).to eq false }
+        it { expect(subject.gamification_enabled?).to eq false }
         it { expect(subject.in_preparation?).to eq true }
 
         it { expect(Mumuki::Domain::Organization::Settings.load(nil)).to be_empty }


### PR DESCRIPTION
# :dart: Goal 

This PR adds a `gamification_enabled?` flag for organizations.

# :memo: Details

This flag is meant to define whether an organization is using gamification or not. 
This implies that this feature is opt in.
