### PR TITLE
Feature forum enhancements

### DIFF
--- a/app/models/concerns/with_scoped_queries.rb
+++ b/app/models/concerns/with_scoped_queries.rb
@@ -16,8 +16,8 @@ module WithScopedQueries
   end
 
   class_methods do
-    def query_methods
-      queriable_attributes.keys
+    def query_methods(excluded_methods)
+      queriable_attributes.keys - excluded_methods.to_a
     end
 
     def scoped_query_module(method)
@@ -28,19 +28,19 @@ module WithScopedQueries
       queriable_attributes.values.flatten
     end
 
-    def actual_params(params, excluded_param)
-      params.reject { |it| it == excluded_param.to_s }
+    def actual_params(params, excluded_params)
+      params.except(*excluded_params)
     end
 
-    def scoped_query_by(params, excluded_param=nil)
-      query_methods.inject(all) do |scope, method|
-        valid_params = valid_params_for(method, params, excluded_param)
+    def scoped_query_by(params, **options)
+      query_methods(options[:excluded_methods]).inject(all) do |scope, method|
+        valid_params = valid_params_for(method, params, options[:excluded_params])
         scoped_query_module(method).query_by valid_params, scope, self
       end
     end
 
-    def valid_params_for(method, params, excluded_param)
-      actual_params = actual_params(params, excluded_param)
+    def valid_params_for(method, params, excluded_params)
+      actual_params = actual_params(params, excluded_params)
       actual_params.permit queriable_attributes[method]
     end
   end

--- a/app/models/concerns/with_scoped_queries/sort.rb
+++ b/app/models/concerns/with_scoped_queries/sort.rb
@@ -10,7 +10,10 @@ module WithScopedQueries::Sort
     normalized_params = normalize_params(sort_param)
     if sort_param.present? && klass.sorting_params_allowed?(*normalized_params)
       sort_method_for(klass, scope, *normalized_params)
-    else
+    else    def opposite(direction)
+      dir = direction.to_s.downcase.to_sym
+      [:asc, :desc].find { |it| it != dir}
+    end
       scope
     end
   end
@@ -34,13 +37,18 @@ module WithScopedQueries::Sort
   end
 
   class_methods do
+    def opposite(direction)
+      dir = direction.to_s.downcase.to_sym
+      [:asc, :desc].find { |it| it != dir}
+    end
+
     def sorting_filters
       sorting_fields.product([:asc, :desc]).map do |it|
         "#{it.first}_#{it.second}"
       end
     end
 
-    def sorting_params_allowed?(sort_param, direction_param=nil)
+    def sorting_params_allowed?(sort_param, direction_param = nil)
       sorting_fields.include?(sort_param.to_sym) && [:asc, :desc].include?(direction_param&.to_sym)
     end
   end

--- a/app/models/concerns/with_scoped_queries/sort.rb
+++ b/app/models/concerns/with_scoped_queries/sort.rb
@@ -10,10 +10,7 @@ module WithScopedQueries::Sort
     normalized_params = normalize_params(sort_param)
     if sort_param.present? && klass.sorting_params_allowed?(*normalized_params)
       sort_method_for(klass, scope, *normalized_params)
-    else    def opposite(direction)
-      dir = direction.to_s.downcase.to_sym
-      [:asc, :desc].find { |it| it != dir}
-    end
+    else
       scope
     end
   end
@@ -39,7 +36,7 @@ module WithScopedQueries::Sort
   class_methods do
     def opposite(direction)
       dir = direction.to_s.downcase.to_sym
-      [:asc, :desc].find { |it| it != dir}
+      [:asc, :desc].find { |it| it != dir }
     end
 
     def sorting_filters

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -135,11 +135,10 @@ class Discussion < ApplicationRecord
   def update_counters_and_timestamps!
     messages_query = messages.reorder(updated_at: :desc)
     useful_messages = messages_query.select &:useful?
-    self.messages_count = messages_query.count
-    self.useful_messages_count = useful_messages.count
-    self.last_initiator_message_at = messages_query.find(&:from_initiator?)&.updated_at
-    self.last_moderator_message_at = useful_messages.first&.updated_at
-    save!
+    update! messages_count: messages_query.count,
+            useful_messages_count: useful_messages.count,
+            last_initiator_message_at: messages_query.find(&:from_initiator?)&.updated_at,
+            last_moderator_message_at: useful_messages.first&.updated_at
   end
 
   def self.debatable_for(klazz, params)

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -17,7 +17,7 @@ class Discussion < ApplicationRecord
 
   markdown_on :description
 
-  sortable :created_at, :upvotes_count, :responses_count, default: :created_at_desc
+  sortable :responses_count, :upvotes_count, :created_at, default: :created_at_desc
   filterable :status, :language
   pageable
 

--- a/db/migrate/20200702165503_add_messages_count_to_discussion.rb
+++ b/db/migrate/20200702165503_add_messages_count_to_discussion.rb
@@ -1,0 +1,8 @@
+class AddMessagesCountToDiscussion < ActiveRecord::Migration[5.1]
+  def change
+    add_column :discussions, :messages_count, :integer, default: 0
+    add_column :discussions, :useful_messages_count, :integer, default: 0
+    add_column :discussions, :last_initiator_message_at, :datetime
+    add_column :discussions, :last_moderator_message_at, :datetime
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200608132959) do
+ActiveRecord::Schema.define(version: 20200702165503) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -117,6 +117,10 @@ ActiveRecord::Schema.define(version: 20200608132959) do
     t.text "manual_evaluation_comment"
     t.integer "upvotes_count", default: 0
     t.bigint "organization_id"
+    t.integer "messages_count", default: 0
+    t.integer "useful_messages_count", default: 0
+    t.datetime "last_initiator_message_at"
+    t.datetime "last_moderator_message_at"
     t.index ["initiator_id"], name: "index_discussions_on_initiator_id"
     t.index ["item_type", "item_id"], name: "index_discussions_on_item_type_and_item_id"
     t.index ["organization_id"], name: "index_discussions_on_organization_id"


### PR DESCRIPTION
This one:

- Fixes the discussion count that is fixed to the results by page currently
- Add a filter to allow ordering by useful_responses.
- It implicitly defines that a `useful` response is one which is given by a moderator or by a user but it's `verified` by a moderator.
- It de-normalizes some counts 
- It changes some filter orders by relevance 

To be done:
- Change `approved` semantic for something more meaningful like `verified` or `validated`