### PR TITLE
Feature kindergarten

### DIFF
--- a/app/models/concerns/with_layout.rb
+++ b/app/models/concerns/with_layout.rb
@@ -2,6 +2,10 @@ module WithLayout
   extend ActiveSupport::Concern
 
   included do
-    enum layout: [:input_right, :input_bottom, :input_kids]
+    enum layout: [:input_right, :input_bottom, :input_primary, :input_kindergarten]
+  end
+
+  def input_kids?
+    input_primary? || input_kindergarten?
   end
 end

--- a/app/models/exercise/challenge.rb
+++ b/app/models/exercise/challenge.rb
@@ -20,6 +20,6 @@ class Challenge < Exercise
 
   def defaults
     super
-    self.layout = self.class.default_layout
+    self.layout ||= self.class.default_layout
   end
 end

--- a/app/models/exercise/problem.rb
+++ b/app/models/exercise/problem.rb
@@ -45,6 +45,12 @@ class Problem < QueriableChallenge
     own_expectations.present? || own_custom_expectations.present?
   end
 
+  # Sets the layout. This method accepts input_kids as a synonym of input_primary
+  # for historical reasons
+  def layout=(layout)
+    self[:layout] = layout.like?(:input_kids) ? :input_primary : layout
+  end
+
   private
 
   def ensure_evaluation_criteria

--- a/app/models/exercise/reading.rb
+++ b/app/models/exercise/reading.rb
@@ -11,6 +11,10 @@ class Reading < Exercise
     false
   end
 
+  def layout=(layout)
+    raise 'can not set a layout different to input_bottom on readings' unless layout.like? :input_bottom
+  end
+
   def queriable?
     false
   end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -115,7 +115,7 @@ describe Assignment, organization_workspace: :test do
     end
 
     context 'should show only the first failed expectation result for kids problems' do
-      let(:problem) { create(:problem, layout: 'input_kids') }
+      let(:problem) { create(:problem, layout: 'input_primary') }
       it { expect(failed_submission.visible_expectation_results.size).to eq 1 }
     end
   end

--- a/spec/models/problem_spec.rb
+++ b/spec/models/problem_spec.rb
@@ -82,4 +82,10 @@ describe Problem, organization_workspace: :test do
 
   end
 
+  describe 'layout' do
+    it { expect(Problem.new(layout: :input_bottom).layout).to be_like :input_bottom }
+    it { expect(Problem.new(layout: :input_primary).layout).to be_like :input_primary }
+    it { expect(Problem.new(layout: :input_kids).layout).to be_like :input_primary }
+    it { expect(Problem.new(layout: :input_kindergarten).layout).to be_like :input_kindergarten }
+  end
 end


### PR DESCRIPTION
# :dart: Goal

This PR introduces the `input_kindergarten` layout concept

# :memo: Details

I am converting the original `input_kids` into an "abstract" layout, and replacing it with `input_primary` and `input_kindergarten` while keeping the original `input_kids?` query method, and making the `layout=` setter to convert `input_kids` into `input_primary` for maximum compatibly.

# :beetle:  Bug fixes

Also, a minor bug - that prevented layout from been initialized in the `Problem` constructor -  has been fixed

# :back: Backward compatible

Aside of the previous considerations, this PR is **not** backward compatible, since it `layout` method will not answer `input_kids` anymore. 

# :eyes: Relations

See https://github.com/mumuki/mumuki-laboratory/pull/1420


