### PR TITLE
Defining with_target_visual_identity mixin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,5 @@ group :test do
 end
 
 gem 'codeclimate-test-reporter', :group => :test, :require => nil
+#
+gem 'mumukit-auth', github: 'mumuki/mumukit-auth', branch: 'master'

--- a/app/models/avatar.rb
+++ b/app/models/avatar.rb
@@ -2,7 +2,7 @@ class Avatar < ApplicationRecord
   include WithTargetVisualIdentity
 
   def self.sample_for(user)
-    with_current_visual_identity_for(user).sample
+    with_current_audience_for(user).sample
   end
 
   def self.sample

--- a/app/models/avatar.rb
+++ b/app/models/avatar.rb
@@ -1,5 +1,7 @@
 class Avatar < ApplicationRecord
+  include WithTargetVisualIdentity
+
   def self.sample
-    Avatar.order('RANDOM()').first
+    with_current_visual_identity.order('RANDOM()').first
   end
 end

--- a/app/models/avatar.rb
+++ b/app/models/avatar.rb
@@ -1,7 +1,11 @@
 class Avatar < ApplicationRecord
   include WithTargetVisualIdentity
 
+  def self.sample_for(user)
+    with_current_visual_identity_for(user).sample
+  end
+
   def self.sample
-    with_current_visual_identity.order('RANDOM()').first
+    order('RANDOM()').first
   end
 end

--- a/app/models/concerns/with_target_visual_identity.rb
+++ b/app/models/concerns/with_target_visual_identity.rb
@@ -1,0 +1,13 @@
+module WithTargetVisualIdentity
+  extend ActiveSupport::Concern
+
+  included do
+    enum target_visual_identity: [:grown_ups, :kids]
+  end
+
+  class_methods do
+    def with_current_visual_identity
+      where(target_visual_identity: Organization.current.target_visual_identity)
+    end
+  end
+end

--- a/app/models/concerns/with_target_visual_identity.rb
+++ b/app/models/concerns/with_target_visual_identity.rb
@@ -2,12 +2,12 @@ module WithTargetVisualIdentity
   extend ActiveSupport::Concern
 
   included do
-    enum target_visual_identity: [:grown_ups, :kids]
+    enum target_audience: [:grown_ups, :kids]
   end
 
   class_methods do
-    def with_current_visual_identity_for(user)
-      where(target_visual_identity: user.current_visual_identity)
+    def with_current_audience_for(user)
+      where(target_audience: user.current_audience)
     end
   end
 end

--- a/app/models/concerns/with_target_visual_identity.rb
+++ b/app/models/concerns/with_target_visual_identity.rb
@@ -6,8 +6,8 @@ module WithTargetVisualIdentity
   end
 
   class_methods do
-    def with_current_visual_identity
-      where(target_visual_identity: Organization.current.target_visual_identity)
+    def with_current_visual_identity_for(user)
+      where(target_visual_identity: user.current_visual_identity)
     end
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -5,6 +5,8 @@ class Organization < ApplicationRecord
 
   include Mumukit::Login::OrganizationHelpers
 
+  include WithTargetVisualIdentity
+
   serialize :profile, Mumuki::Domain::Organization::Profile
   serialize :settings, Mumuki::Domain::Organization::Settings
   serialize :theme, Mumuki::Domain::Organization::Theme

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -173,8 +173,12 @@ class User < ApplicationRecord
     sequence[0..count + lookahead - 1]
   end
 
-  def current_visual_identity
-    current_organic_context&.target_visual_identity
+  def current_audience
+    current_organic_context&.target_audience
+  end
+
+  def placeholder_image_url
+    PLACEHOLDER_IMAGE_URL
   end
 
   private
@@ -211,10 +215,6 @@ class User < ApplicationRecord
 
   def self.buried_profile
     (@buried_profile || {}).slice(:first_name, :last_name, :email)
-  end
-
-  def placeholder_image_url
-    PLACEHOLDER_IMAGE_URL
   end
 
   def current_organic_context

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,14 +30,14 @@ class User < ApplicationRecord
 
   has_many :exams, through: :exam_authorizations
 
-  after_initialize :init
-
   enum gender: %i(female male other unspecified)
 
   belongs_to :avatar, optional: true
 
   before_validation :set_uid!
   validates :uid, presence: true
+
+  PLACEHOLDER_IMAGE_URL = 'user_shape.png'.freeze
 
   resource_fields :uid, :social_id, :email, :permissions, :verified_first_name, :verified_last_name, *profile_fields
 
@@ -146,7 +146,7 @@ class User < ApplicationRecord
   end
 
   def profile_picture
-    avatar&.image_url || image_url
+    avatar&.image_url || image_url || placeholder_image_url
   end
 
   def bury!
@@ -169,6 +169,10 @@ class User < ApplicationRecord
     sequence[0..count + lookahead - 1]
   end
 
+  def current_visual_identity
+    current_organic_context&.target_visual_identity
+  end
+
   private
 
   def set_uid!
@@ -176,7 +180,7 @@ class User < ApplicationRecord
   end
 
   def init
-    self.avatar = Avatar.sample unless profile_picture.present?
+    self.avatar ||= Avatar.sample_for(self)
   end
 
   def self.sync_key_id_field
@@ -200,5 +204,17 @@ class User < ApplicationRecord
 
   def self.buried_profile
     (@buried_profile || {}).slice(:first_name, :last_name, :email)
+  end
+
+  def placeholder_image_url
+    PLACEHOLDER_IMAGE_URL
+  end
+
+  def current_organic_context
+    if Organization.current?
+      Organization.current
+    else
+      main_organization
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -184,7 +184,10 @@ class User < ApplicationRecord
   end
 
   def init
-    self.avatar = Avatar.sample_for(self) unless custom_profile_picture.present?
+    if custom_profile_picture.blank?
+      self.avatar = Avatar.sample_for(self)
+      save if persisted?
+    end
   end
 
   def self.sync_key_id_field

--- a/db/migrate/20200717143830_add_target_visual_identity_to_organizations_and_avatars.rb
+++ b/db/migrate/20200717143830_add_target_visual_identity_to_organizations_and_avatars.rb
@@ -1,0 +1,6 @@
+class AddTargetVisualIdentityToOrganizationsAndAvatars < ActiveRecord::Migration[5.1]
+  def change
+    add_column :organizations, :target_visual_identity, :integer, default: 0
+    add_column :avatars, :target_visual_identity, :integer, default: 0
+  end
+end

--- a/db/migrate/20200717143830_add_target_visual_identity_to_organizations_and_avatars.rb
+++ b/db/migrate/20200717143830_add_target_visual_identity_to_organizations_and_avatars.rb
@@ -1,6 +1,6 @@
 class AddTargetVisualIdentityToOrganizationsAndAvatars < ActiveRecord::Migration[5.1]
   def change
-    add_column :organizations, :target_visual_identity, :integer, default: 0
-    add_column :avatars, :target_visual_identity, :integer, default: 0
+    add_column :organizations, :target_audience, :integer, default: 0
+    add_column :avatars, :target_audience, :integer, default: 0
   end
 end

--- a/lib/mumuki/domain/factories.rb
+++ b/lib/mumuki/domain/factories.rb
@@ -1,5 +1,6 @@
 require_relative './factories/api_client_factory'
 require_relative './factories/assignments_factory'
+require_relative './factories/avatar_factory'
 require_relative './factories/book_factory'
 require_relative './factories/chapter_factory'
 require_relative './factories/complement_factory'

--- a/lib/mumuki/domain/factories/avatar_factory.rb
+++ b/lib/mumuki/domain/factories/avatar_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :avatar do
     image_url { Faker::Internet.url }
-    target_visual_identity { :grown_ups }
+    target_audience { :grown_ups }
   end
 end

--- a/lib/mumuki/domain/factories/avatar_factory.rb
+++ b/lib/mumuki/domain/factories/avatar_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :avatar do
+    image_url { Faker::Internet.url }
+    target_visual_identity { :grown_ups }
+  end
+end

--- a/lib/mumuki/domain/factories/user_factory.rb
+++ b/lib/mumuki/domain/factories/user_factory.rb
@@ -6,6 +6,5 @@ FactoryBot.define do
     last_name { Faker::Name.last_name }
     gender { 1 }
     birthdate { Date.today }
-    avatar { Avatar.new image_url: 'user_shape.png' }
   end
 end

--- a/lib/mumuki/domain/helpers/organization.rb
+++ b/lib/mumuki/domain/helpers/organization.rb
@@ -66,6 +66,10 @@ module Mumuki::Domain::Helpers::Organization
       Mumukit::Platform::Organization.current
     end
 
+    def current?
+      Mumukit::Platform::Organization.current?
+    end
+
     def parse(json)
       json
         .slice(:name)

--- a/lib/mumuki/domain/helpers/user.rb
+++ b/lib/mumuki/domain/helpers/user.rb
@@ -71,12 +71,14 @@ module Mumuki::Domain::Helpers::User
     "#{full_name} <#{email}> [#{uid}]"
   end
 
-  ## Accesible organizations
+  ## Accessible organizations
 
-  def student_granted_organizations
-    permissions.student_granted_organizations.map do |org|
-      Mumukit::Platform::Organization.find_by_name!(org) rescue nil
-    end.compact
+  [:any_granted_organizations, :student_granted_organizations].each do |granted_organization_method|
+    define_method(granted_organization_method) do
+      permissions.send(granted_organization_method).map do |org|
+        Mumukit::Platform::Organization.find_by_name!(org) rescue nil
+      end.compact
+    end
   end
 
   def has_student_granted_organizations?
@@ -84,7 +86,7 @@ module Mumuki::Domain::Helpers::User
   end
 
   def main_organization
-    student_granted_organizations.first
+    student_granted_organizations.first || any_granted_organizations.first
   end
 
   def has_main_organization?

--- a/lib/mumuki/domain/helpers/user.rb
+++ b/lib/mumuki/domain/helpers/user.rb
@@ -13,6 +13,8 @@ module Mumuki::Domain::Helpers::User
            :protect!,
            :protect_delegation!,
            :protect_permissions_assignment!,
+           :student_granted_organizations,
+           :any_granted_organizations,
            to: :permissions
 
   def platform_class_name
@@ -73,12 +75,8 @@ module Mumuki::Domain::Helpers::User
 
   ## Accessible organizations
 
-  [:any_granted_organizations, :student_granted_organizations].each do |granted_organization_method|
-    define_method(granted_organization_method) do
-      permissions.send(granted_organization_method).map do |org|
-        Mumukit::Platform::Organization.find_by_name!(org) rescue nil
-      end.compact
-    end
+  revamp_accessor :any_granted_organizations, :student_granted_organizations do |_, _, result|
+    result.map { |org| Mumukit::Platform::Organization.find_by_name!(org) rescue nil }.compact
   end
 
   def has_student_granted_organizations?
@@ -87,10 +85,6 @@ module Mumuki::Domain::Helpers::User
 
   def main_organization
     student_granted_organizations.first || any_granted_organizations.first
-  end
-
-  def has_main_organization?
-    student_granted_organizations.length == 1
   end
 
   def has_immersive_main_organization?

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200702165503) do
+ActiveRecord::Schema.define(version: 20200717143830) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 20200702165503) do
   create_table "avatars", force: :cascade do |t|
     t.string "image_url"
     t.string "description"
+    t.integer "target_visual_identity", default: 0
   end
 
   create_table "books", id: :serial, force: :cascade do |t|
@@ -308,6 +309,7 @@ ActiveRecord::Schema.define(version: 20200702165503) do
     t.text "theme", default: "{}", null: false
     t.text "profile", default: "{}", null: false
     t.integer "progressive_display_lookahead"
+    t.integer "target_visual_identity", default: 0
     t.index ["book_id"], name: "index_organizations_on_book_id"
     t.index ["name"], name: "index_organizations_on_name", unique: true
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 20200717143830) do
   create_table "avatars", force: :cascade do |t|
     t.string "image_url"
     t.string "description"
-    t.integer "target_visual_identity", default: 0
+    t.integer "target_audience", default: 0
   end
 
   create_table "books", id: :serial, force: :cascade do |t|
@@ -309,7 +309,7 @@ ActiveRecord::Schema.define(version: 20200717143830) do
     t.text "theme", default: "{}", null: false
     t.text "profile", default: "{}", null: false
     t.integer "progressive_display_lookahead"
-    t.integer "target_visual_identity", default: 0
+    t.integer "target_audience", default: 0
     t.index ["book_id"], name: "index_organizations_on_book_id"
     t.index ["name"], name: "index_organizations_on_name", unique: true
   end
@@ -401,7 +401,6 @@ ActiveRecord::Schema.define(version: 20200717143830) do
 
   add_foreign_key "chapters", "topics"
   add_foreign_key "complements", "guides"
-  add_foreign_key "exams", "courses"
   add_foreign_key "exams", "guides"
   add_foreign_key "lessons", "guides"
   add_foreign_key "organizations", "books"

--- a/spec/lib/user_helpers_spec.rb
+++ b/spec/lib/user_helpers_spec.rb
@@ -147,7 +147,6 @@ describe Mumuki::Domain::Helpers::User do
     context 'no organization' do
       it { expect(user.student_granted_organizations).to eq [] }
       it { expect(user.has_student_granted_organizations?).to be false }
-      it { expect(user.has_main_organization?).to be false }
       it { expect(user.has_immersive_main_organization?).to be false }
     end
 
@@ -157,7 +156,6 @@ describe Mumuki::Domain::Helpers::User do
 
       it { expect(user.student_granted_organizations).to eq [organization] }
       it { expect(user.has_student_granted_organizations?).to be true }
-      it { expect(user.has_main_organization?).to be true }
       it { expect(user.has_immersive_main_organization?).to be false }
 
       context 'when immersive' do

--- a/spec/lib/user_helpers_spec.rb
+++ b/spec/lib/user_helpers_spec.rb
@@ -142,6 +142,7 @@ describe Mumuki::Domain::Helpers::User do
 
   describe 'student_granted_organizations' do
     before { Mumukit::Platform.config.organization_class = class_double('UserSpecDemoOrganization') }
+    after { Mumukit::Platform.config.organization_class = nil }
 
     context 'no organization' do
       it { expect(user.student_granted_organizations).to eq [] }

--- a/spec/models/with_target_visual_identity_spec.rb
+++ b/spec/models/with_target_visual_identity_spec.rb
@@ -1,23 +1,23 @@
 require 'spec_helper'
 
 describe WithTargetVisualIdentity do
-  let!(:kids_organization) { create(:organization, target_visual_identity: :kids) }
-  let!(:grown_ups_organization) { create(:organization, target_visual_identity: :grown_ups, name: 'for_grown_ups') }
+  let!(:kids_organization) { create(:organization, target_audience: :kids) }
+  let!(:grown_ups_organization) { create(:organization, target_audience: :grown_ups, name: 'for_grown_ups') }
 
-  let!(:kids_avatars) { create_list(:avatar, 3, target_visual_identity: :kids) }
-  let!(:grown_ups_avatars) { create_list(:avatar, 3, target_visual_identity: :grown_ups) }
+  let!(:kids_avatars) { create_list(:avatar, 3, target_audience: :kids) }
+  let!(:grown_ups_avatars) { create_list(:avatar, 3, target_audience: :grown_ups) }
 
   let(:user) { create(:user) }
 
-  context '.with_current_visual_identity' do
+  context '.with_current_audience' do
     context 'when there is not a current organization' do
       context 'and student has no granted organizations' do
-        it { expect(Avatar.with_current_visual_identity_for(user)).to be_empty }
+        it { expect(Avatar.with_current_audience_for(user)).to be_empty }
       end
       context 'and student has no granted organizations' do
         before { user.add_permission! :teacher, grown_ups_organization; user.save! }
 
-        it { expect(Avatar.with_current_visual_identity_for(user)).to eq grown_ups_avatars }
+        it { expect(Avatar.with_current_audience_for(user)).to eq grown_ups_avatars }
       end
     end
 
@@ -25,12 +25,12 @@ describe WithTargetVisualIdentity do
       before { kids_organization.switch! }
 
       context 'and student has no granted organizations' do
-        it { expect(Avatar.with_current_visual_identity_for(user)).to eq kids_avatars }
+        it { expect(Avatar.with_current_audience_for(user)).to eq kids_avatars }
       end
       context 'and student has no granted organizations' do
         before { user.add_permission! :teacher, grown_ups_organization; user.save! }
 
-        it { expect(Avatar.with_current_visual_identity_for(user)).to eq kids_avatars }
+        it { expect(Avatar.with_current_audience_for(user)).to eq kids_avatars }
       end
     end
   end

--- a/spec/models/with_target_visual_identity_spec.rb
+++ b/spec/models/with_target_visual_identity_spec.rb
@@ -1,24 +1,37 @@
 require 'spec_helper'
 
 describe WithTargetVisualIdentity do
-  let(:kids_organization) { create(:organization, target_visual_identity: :kids) }
-  let(:grown_ups_organization) { create(:organization, target_visual_identity: :grown_ups) }
+  let!(:kids_organization) { create(:organization, target_visual_identity: :kids) }
+  let!(:grown_ups_organization) { create(:organization, target_visual_identity: :grown_ups, name: 'for_grown_ups') }
 
-  let(:kids_avatars) { create_list(:avatar, 3, target_visual_identity: :kids) }
-  let(:grown_ups_avatars) { create_list(:avatar, 3, target_visual_identity: :grown_ups) }
+  let!(:kids_avatars) { create_list(:avatar, 3, target_visual_identity: :kids) }
+  let!(:grown_ups_avatars) { create_list(:avatar, 3, target_visual_identity: :grown_ups) }
+
+  let(:user) { create(:user) }
 
   context '.with_current_visual_identity' do
+    context 'when there is not a current organization' do
+      context 'and student has no granted organizations' do
+        it { expect(Avatar.with_current_visual_identity_for(user)).to be_empty }
+      end
+      context 'and student has no granted organizations' do
+        before { user.add_permission! :teacher, grown_ups_organization; user.save! }
 
-    context 'sets scope correctly for kids' do
-      before { kids_organization.switch! }
-
-      it { expect(Avatar.with_current_visual_identity).to eq kids_avatars }
+        it { expect(Avatar.with_current_visual_identity_for(user)).to eq grown_ups_avatars }
+      end
     end
 
-    context 'sets scope correctly for kids' do
-      before { grown_ups_organization.switch! }
+    context 'when there is a current organization' do
+      before { kids_organization.switch! }
 
-      it { expect(Avatar.with_current_visual_identity).to eq grown_ups_avatars }
+      context 'and student has no granted organizations' do
+        it { expect(Avatar.with_current_visual_identity_for(user)).to eq kids_avatars }
+      end
+      context 'and student has no granted organizations' do
+        before { user.add_permission! :teacher, grown_ups_organization; user.save! }
+
+        it { expect(Avatar.with_current_visual_identity_for(user)).to eq kids_avatars }
+      end
     end
   end
 end

--- a/spec/models/with_target_visual_identity_spec.rb
+++ b/spec/models/with_target_visual_identity_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe WithTargetVisualIdentity do
+  let(:kids_organization) { create(:organization, target_visual_identity: :kids) }
+  let(:grown_ups_organization) { create(:organization, target_visual_identity: :grown_ups) }
+
+  let(:kids_avatars) { create_list(:avatar, 3, target_visual_identity: :kids) }
+  let(:grown_ups_avatars) { create_list(:avatar, 3, target_visual_identity: :grown_ups) }
+
+  context '.with_current_visual_identity' do
+
+    context 'sets scope correctly for kids' do
+      before { kids_organization.switch! }
+
+      it { expect(Avatar.with_current_visual_identity).to eq kids_avatars }
+    end
+
+    context 'sets scope correctly for kids' do
+      before { grown_ups_organization.switch! }
+
+      it { expect(Avatar.with_current_visual_identity).to eq grown_ups_avatars }
+    end
+  end
+end


### PR DESCRIPTION
# :dart: Goal

This PR introduces the `with_target_visual_identity` mixin
Resolves #92 

# :memo: Details

This one intends to be one of the two _target-related_ flags.
This one defines which will be the target visual identity of the organization and, in this case, the avatars.
Currently we have two very different aesthetics, the one for kids and the one for grown-ups, and this flag aims to allow to render certain resources based on the current one (which is determined by the current Organization).

The other flag, which isn't added here, is proposed to be `target_audience` which will define whether that organization is intended for `:kindergaten, :primary and (:secondary_and_above || :secondary, :adults)` -> I prefer the later.

This means that an organization may have a kids identity _visuallly_ but it is meant to be used by adults. This would be the case of an organization which uses kids exercises to teach adults programming basics.

  
# :back: Backward compatible

This PR is backward compatible, as it only adds new behavior. 

# :eyes: Reviewer questions

Would like to hear opinions about the two proposed flags.
In particular I'm not sure whether `target_visual_identity` is the best name and if we should use another word instead of `grown_ups`. I think that there isn't any doubt about `kids` as it matches the semantics introduced by @flbulgarelli.

# :heavy_plus_sign: Extra

Please see [my comment](https://github.com/mumuki/mumuki-domain/pull/106#pullrequestreview-450923955) bellow for extra information about these changes