### PR TITLE
Feature serverless evaluation

### DIFF
--- a/app/models/concerns/submittable/solvable.rb
+++ b/app/models/concerns/submittable/solvable.rb
@@ -1,12 +1,16 @@
 module Solvable
-  def submit_solution!(user, attributes={})
-    assignment, _ = find_assignment_and_submit! user, attributes[:content].to_mumuki_solution(language)
+  def submit_solution!(user, submission_attributes={})
+    assignment, _ = find_assignment_and_submit! user, solution_for(submission_attributes)
     try_solve_discussions(user) if assignment.solved?
     assignment
   end
 
   def run_tests!(params)
     language.run_tests!(params.merge(locale: locale, expectations: expectations, custom_expectations: custom_expectations))
+  end
+
+  def solution_for(submission_attributes)
+    submission_attributes[:content].to_mumuki_solution(language)
   end
 end
 

--- a/app/models/concerns/submittable/solvable.rb
+++ b/app/models/concerns/submittable/solvable.rb
@@ -10,7 +10,9 @@ module Solvable
   end
 
   def solution_for(submission_attributes)
-    submission_attributes[:content].to_mumuki_solution(language)
+    submission_attributes[:content]
+      .to_mumuki_solution(language)
+      .with_client_result(submission_attributes[:client_result])
   end
 end
 

--- a/lib/mumuki/domain/submission/base.rb
+++ b/lib/mumuki/domain/submission/base.rb
@@ -9,6 +9,7 @@ class Mumuki::Domain::Submission::Base
                 :submission_id, :queries, :query_results, :manual_evaluation_comment]
 
   attr_accessor *ATTRIBUTES
+  attr_accessor :client_result
 
   def self.from_attributes(*args)
     new ATTRIBUTES.zip(args).to_h
@@ -24,6 +25,11 @@ class Mumuki::Domain::Submission::Base
     save_results! results, assignment
     notify_results! results, assignment
     results
+  end
+
+  def with_client_result(result)
+    self.client_result = result if result.present?
+    self
   end
 
   def evaluate!(assignment)

--- a/lib/mumuki/domain/submission/solution.rb
+++ b/lib/mumuki/domain/submission/solution.rb
@@ -2,6 +2,8 @@ class Mumuki::Domain::Submission::Solution < Mumuki::Domain::Submission::Persist
   attr_accessor :content
 
   def try_evaluate!(assignment)
-    assignment.run_tests!(content: content, client_result: client_result).except(:response_type)
+    assignment
+      .run_tests!({client_result: client_result}.compact.merge(content: content))
+      .except(:response_type)
   end
 end

--- a/lib/mumuki/domain/submission/solution.rb
+++ b/lib/mumuki/domain/submission/solution.rb
@@ -2,6 +2,6 @@ class Mumuki::Domain::Submission::Solution < Mumuki::Domain::Submission::Persist
   attr_accessor :content
 
   def try_evaluate!(assignment)
-    assignment.run_tests!(content: content).except(:response_type)
+    assignment.run_tests!(content: content, client_result: client_result).except(:response_type)
   end
 end


### PR DESCRIPTION
# :dart: Goal 

This PR allows clients to send an additional, non-persistable `client_result` param to `try_submit!`, which is the cornerstone of the serverless evaluation mode, that will allow browsers to propose evaluation results, which may be faster o better than server-side evaluation

# :memo: Notes

This PR just sends the new attributes to the bridge, which does not have any impact by itself. Runners may ignore the `client_result` completely. 

# :back: Backward compatibility

This PR is 100% backwards compatible

# :soon: Future work

In order to improve performance, further iterations of this evaluation strategy may even avoid hitting the runner. However, care should be taken that results are not tampered by malicious clients. , Trusting the `client_result` is currently a responsibility of the runner, but in the future, it may be **also** a responsability of the exercise - an exercise may have a `serverless_evaluation_enabled`, the organization - or workspace - or even a domain logic like `exam? => serverless evaluation disabled`. 

