### PR TITLE
Adding the ability to restrict forum to just trusted users

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -105,17 +105,8 @@ class Organization < ApplicationRecord
   # ask for help in this organization
   #
   # Warning: this method does not strictly check user's permission
-  def ask_for_help_enabled?(user = nil)
-    report_issue_enabled? || community_link.present? || can_create_discussions?(user)
-  end
-
-  # Tells if the given user can
-  # create discussion in this organization
-  #
-  # This is true only when this organization has a forum and the user
-  # has the discusser pseudo-permission
-  def can_create_discussions?(user = nil)
-    forum_enabled? && (!user || user.discusser_of?(self))
+  def ask_for_help_enabled?(user)
+    report_issue_enabled? || community_link.present? || user.can_discuss_in?(self)
   end
 
   def import_from_resource_h!(resource_h)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -169,6 +169,22 @@ class User < ApplicationRecord
     sequence[0..count + lookahead - 1]
   end
 
+  # Tells if the given user can discuss in an organization
+  #
+  # This is true only when this organization has the forum enabled and the user
+  # has the discusser pseudo-permission and the discusser is trusted
+  def can_discuss_in?(organization)
+    organization.forum_enabled? && discusser_of?(organization) && trusted_as_discusser_in?(organization)
+  end
+
+  def trusted_as_discusser_in?(organization)
+    trusted_for_forum? || !organization.forum_only_for_trusted?
+  end
+
+  def can_discuss_here?
+    can_discuss_in? Organization.current
+  end
+
   private
 
   def set_uid!

--- a/db/migrate/20200730221001_add_trusted_for_forum_to_user.rb
+++ b/db/migrate/20200730221001_add_trusted_for_forum_to_user.rb
@@ -1,0 +1,5 @@
+class AddTrustedForForumToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :trusted_for_forum, :boolean, default: false
+  end
+end

--- a/db/migrate/20200730221001_add_trusted_for_forum_to_user.rb
+++ b/db/migrate/20200730221001_add_trusted_for_forum_to_user.rb
@@ -1,5 +1,5 @@
 class AddTrustedForForumToUser < ActiveRecord::Migration[5.1]
   def change
-    add_column :users, :trusted_for_forum, :boolean, default: false
+    add_column :users, :trusted_for_forum, :boolean
   end
 end

--- a/lib/mumuki/domain/organization/settings.rb
+++ b/lib/mumuki/domain/organization/settings.rb
@@ -1,20 +1,21 @@
 class Mumuki::Domain::Organization::Settings < Mumukit::Platform::Model
   include Mumukit::Login::LoginSettingsHelpers
 
-  model_attr_accessor :login_methods,
+  model_attr_accessor :disabled_from,
+                      :embeddable?,
+                      :feedback_suggestions_enabled?,
+                      :forum_discussions_minimal_role,
+                      :forum_enabled?,
+                      :forum_only_for_trusted?,
+                      :gamification_enabled?,
+                      :immersive?,
+                      :in_preparation_until,
+                      :login_methods,
                       :login_provider,
                       :login_provider_settings,
-                      :forum_discussions_minimal_role,
-                      :raise_hand_enabled?,
-                      :feedback_suggestions_enabled?,
                       :public?,
-                      :embeddable?,
-                      :immersive?,
-                      :forum_enabled?,
-                      :report_issue_enabled?,
-                      :disabled_from,
-                      :in_preparation_until,
-                      :gamification_enabled?
+                      :raise_hand_enabled?,
+                      :report_issue_enabled?
 
   def private?
     !public?

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200702165503) do
+ActiveRecord::Schema.define(version: 20200730221001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -383,6 +383,7 @@ ActiveRecord::Schema.define(version: 20200702165503) do
     t.string "verified_last_name"
     t.bigint "avatar_id"
     t.datetime "disabled_at"
+    t.boolean "trusted_for_forum", default: false
     t.index ["disabled_at"], name: "index_users_on_disabled_at"
     t.index ["last_organization_id"], name: "index_users_on_last_organization_id"
     t.index ["uid"], name: "index_users_on_uid", unique: true
@@ -390,7 +391,6 @@ ActiveRecord::Schema.define(version: 20200702165503) do
 
   add_foreign_key "chapters", "topics"
   add_foreign_key "complements", "guides"
-  add_foreign_key "exams", "courses"
   add_foreign_key "exams", "guides"
   add_foreign_key "lessons", "guides"
   add_foreign_key "organizations", "books"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -383,7 +383,7 @@ ActiveRecord::Schema.define(version: 20200730221001) do
     t.string "verified_last_name"
     t.bigint "avatar_id"
     t.datetime "disabled_at"
-    t.boolean "trusted_for_forum", default: false
+    t.boolean "trusted_for_forum"
     t.index ["disabled_at"], name: "index_users_on_disabled_at"
     t.index ["last_organization_id"], name: "index_users_on_last_organization_id"
     t.index ["uid"], name: "index_users_on_uid", unique: true

--- a/spec/lib/organization_helpers_spec.rb
+++ b/spec/lib/organization_helpers_spec.rb
@@ -20,6 +20,7 @@ describe Mumukit::Platform::Organization do
         feedback_suggestions_enabled: true,
         raise_hand_enabled: true,
         forum_enabled: true,
+        forum_only_for_trusted: true,
         report_issue_enabled: true,
         public: false,
         gamification_enabled: true,
@@ -92,6 +93,7 @@ describe Mumukit::Platform::Organization do
         it { expect(subject.raise_hand_enabled?).to be true }
         it { expect(subject.report_issue_enabled?).to be true }
         it { expect(subject.forum_enabled?).to be true }
+        it { expect(subject.forum_only_for_trusted?).to be true }
         it { expect(subject.feedback_suggestions_enabled?).to be true }
         it { expect(subject.public?).to eq false }
         it { expect(subject.gamification_enabled?).to be true }
@@ -112,6 +114,7 @@ describe Mumukit::Platform::Organization do
                             raise_hand_enabled: false,
                             report_issue_enabled: false,
                             forum_enabled: false,
+                            forum_only_for_trusted: false,
                             forum_discussions_minimal_role: 'teacher',
                             gamification_enabled: false,
                             login_methods: [:google]) }
@@ -123,6 +126,7 @@ describe Mumukit::Platform::Organization do
         it { expect(subject.forum_discussions_minimal_role).to be :teacher }
         it { expect(subject.raise_hand_enabled?).to be false }
         it { expect(subject.forum_enabled?).to be false }
+        it { expect(subject.forum_only_for_trusted?).to be false }
         it { expect(subject.report_issue_enabled?).to be false }
         it { expect(subject.feedback_suggestions_enabled?).to be false }
         it { expect(subject.public?).to eq true }

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -24,18 +24,15 @@ describe Organization, organization_workspace: :test do
 
     context 'when non assistance medium present' do
       it { expect(organization.ask_for_help_enabled? user).to be false }
-      it { expect(organization.ask_for_help_enabled?).to be false }
     end
 
     context 'when can report issues' do
       before { organization.report_issue_enabled = true }
       it { expect(organization.ask_for_help_enabled? user).to be true }
-      it { expect(organization.ask_for_help_enabled?).to be true }
     end
     context 'when there is a community link' do
       before { organization.community_link = 'https://an-external-mumuki-forum.org' }
       it { expect(organization.ask_for_help_enabled? user).to be true }
-      it { expect(organization.ask_for_help_enabled?).to be true }
     end
 
     context 'when forum is enabled' do
@@ -43,13 +40,11 @@ describe Organization, organization_workspace: :test do
 
       context 'when user does not meet minimal permissions' do
         it { expect(organization.ask_for_help_enabled? user).to be false }
-        it { expect(organization.ask_for_help_enabled?).to be true }
       end
 
       context 'when user meets minimal permissions' do
         before { user.make_student_of! organization }
         it { expect(organization.ask_for_help_enabled? user).to be true }
-        it { expect(organization.ask_for_help_enabled?).to be true }
       end
     end
   end


### PR DESCRIPTION
# :dart: Goal

This PR allows certain organizations to restrict the forum for `trusted_for_forum` users. In the current implementation it's just a boolean but with the intention to be expanded with age validation, for example.
 
# :arrow_backward: Retro-compatibility

This PR is fully backwards compatible and should not affect any existing organization as the default is for users not to be trusted but the forum will be available for trusted and untrusted users by default.