### PR TITLE
Chore forum general improvements

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -20,6 +20,8 @@ class Assignment < Progress
   delegate :language, :name, :navigable_parent, :settings,
            :limited?, :input_kids?, :choice?, :results_hidden?, to: :exercise
 
+  delegate :completed?, :solved?, to: :submission_status
+
   alias_attribute :status, :submission_status
   alias_attribute :attempts_count, :attemps_count
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -18,7 +18,7 @@ class Book < Content
   end
 
   def discussions_in_organization(organization = Organization.current)
-    Discussion.all.where(organization: organization).includes(exercise: [:language, :guide])
+    Discussion.where(organization: organization).includes(exercise: [:language, :guide])
   end
 
   def first_chapter

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -8,8 +8,6 @@ class Book < Content
   has_many :complements, dependent: :destroy
 
   has_many :exercises, through: :chapters
-  has_many :discussions, through: :exercises
-  organic_on :discussions
 
   delegate :first_lesson, to: :first_chapter
 
@@ -17,6 +15,10 @@ class Book < Content
 
   def to_s
     slug
+  end
+
+  def discussions_in_organization(organization = Organization.current)
+    Discussion.all.where(organization: organization).includes(exercise: [:language, :guide])
   end
 
   def first_chapter

--- a/app/models/concerns/contextualization.rb
+++ b/app/models/concerns/contextualization.rb
@@ -25,7 +25,7 @@ module Contextualization
 
     delegate :visible_success_output?, to: :exercise
     delegate :output_content_type, to: :language
-    delegate :should_retry?, :to_submission_status, :completed?, :solved?, *Mumuki::Domain::Status::Submission.test_selectors, to: :submission_status
+    delegate :should_retry?, :to_submission_status, *Mumuki::Domain::Status::Submission.test_selectors, to: :submission_status
     delegate :inspection_keywords, to: :exercise
   end
 

--- a/app/models/concerns/submittable/solvable.rb
+++ b/app/models/concerns/submittable/solvable.rb
@@ -1,7 +1,7 @@
 module Solvable
   def submit_solution!(user, submission_attributes={})
     assignment, _ = find_assignment_and_submit! user, solution_for(submission_attributes)
-    try_solve_discussions(user) if assignment.solved?
+    try_solve_discussions!(user) if assignment.solved?
     assignment
   end
 

--- a/app/models/concerns/with_discussions.rb
+++ b/app/models/concerns/with_discussions.rb
@@ -14,7 +14,7 @@ module WithDiscussions
     nil
   end
 
-  def try_solve_discussions(user)
+  def try_solve_discussions!(user)
     discussions.where(initiator: user).map(&:try_solve!)
   end
 

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -138,10 +138,10 @@ class Discussion < ApplicationRecord
   def update_counters!
     messages_query = messages_by_updated_at
     validated_messages = messages_query.select &:validated?
-    requires_moderator_response = messages_query.find { |it| it.validated? || it.question? }&.from_initiator?
+    has_moderator_response = messages_query.find { |it| it.validated? || it.question? }&.validated?
     update! messages_count: messages_query.count,
             validated_messages_count: validated_messages.count,
-            requires_moderator_response: requires_moderator_response
+            requires_moderator_response: !has_moderator_response
   end
 
   def update_last_moderator_access!(user)

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -105,10 +105,6 @@ class Discussion < ApplicationRecord
     reachable_statuses_for(user).include? status
   end
 
-  def allowed_statuses_for(user)
-    status.allowed_statuses_for(user, self)
-  end
-
   def update_status!(status, user)
     update!(status: status) if reachable_status_for?(user, status)
   end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -121,6 +121,10 @@ class Discussion < ApplicationRecord
     responses_count > 0
   end
 
+  def has_validated_responses?
+    validated_messages_count > 0
+  end
+
   def subscribe_initiator!
     initiator.subscribe_to! self
   end

--- a/lib/mumuki/domain/factories/discussion_factory.rb
+++ b/lib/mumuki/domain/factories/discussion_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :discussion do
-    title { 'A discussion' }
-    description { 'A discussion description' }
+    title { Faker::Lorem.sentence(word_count: 2) }
+    description { Faker::Lorem.sentence(word_count: 5) }
     initiator { create(:user) }
     item { create(:exercise) }
     organization { Organization.current rescue nil }

--- a/lib/mumuki/domain/status/discussion/discussion.rb
+++ b/lib/mumuki/domain/status/discussion/discussion.rb
@@ -14,10 +14,6 @@ module Mumuki::Domain::Status::Discussion
     define_method(selector) { false }
   end
 
-  def allowed_for?(*)
-    true
-  end
-
   def reachable_statuses_for_moderator(*)
     []
   end
@@ -36,10 +32,6 @@ module Mumuki::Domain::Status::Discussion
     else
       reachable_statuses_for_initiator(discussion)
     end
-  end
-
-  def allowed_statuses_for(user, discussion)
-    STATUSES.select { |it| it.allowed_for?(user, discussion) }
   end
 
   def as_json(_options={})

--- a/lib/mumuki/domain/status/discussion/opened.rb
+++ b/lib/mumuki/domain/status/discussion/opened.rb
@@ -5,6 +5,14 @@ module Mumuki::Domain::Status::Discussion::Opened
     true
   end
 
+  def self.reachable_statuses_for_initiator(discussion)
+    if discussion.has_validated_responses?
+      [Mumuki::Domain::Status::Discussion::PendingReview]
+    else
+      [Mumuki::Domain::Status::Discussion::Closed]
+    end
+  end
+
   def self.reachable_statuses_for_moderator(discussion)
     if discussion.has_responses?
       [Mumuki::Domain::Status::Discussion::Closed, Mumuki::Domain::Status::Discussion::Solved]

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -5,19 +5,20 @@ describe Discussion, organization_workspace: :test do
   context 'when created' do
     let(:initiator) { create(:user) }
     let(:student) { create(:user) }
-    let(:problem) { create(:problem) }
+    let(:problem) { create(:indexed_exercise) }
     let(:discussion) { problem.discuss! initiator, title: 'Need help' }
     let(:moderator) { create(:user, permissions: {moderator: 'test/*'}) }
 
     it { expect(discussion.new_record?).to be false }
     it { expect(discussion.has_responses?).to be false }
+    it { expect(discussion.has_validated_responses?).to be false }
     it { expect(discussion.messages).to eq [] }
     it { expect(discussion.initiator).to eq initiator }
     it { expect(discussion.title).to eq 'Need help' }
     it { expect(discussion.item).to eq problem }
     it { expect(initiator.subscribed_to? discussion).to be true }
     it { expect(discussion.status).to eq :opened }
-    it { expect(discussion.reachable_statuses_for initiator).to eq [] }
+    it { expect(discussion.reachable_statuses_for initiator).to eq [:closed] }
     it { expect(discussion.reachable_statuses_for moderator).to eq [:closed] }
     it { expect(discussion.reachable_statuses_for student).to eq [] }
     it { expect(discussion.commentable_by? student).to be true }
@@ -27,44 +28,123 @@ describe Discussion, organization_workspace: :test do
       before { discussion.submit_message!({content: 'I forgot to say this'}, initiator) }
 
       it { expect(discussion.has_responses?).to be false }
+      it { expect(discussion.has_validated_responses?).to be false }
       it { expect(discussion.messages.first.content).to eq 'I forgot to say this' }
       it { expect(initiator.unread_discussions).to eq [] }
-      it { expect(discussion.reachable_statuses_for initiator).to eq [] }
+      it { expect(discussion.reachable_statuses_for initiator).to eq [:closed] }
       it { expect(discussion.reachable_statuses_for moderator).to eq [:closed] }
       it { expect(discussion.reachable_statuses_for student).to eq [] }
 
-      describe 'and closes the discussion then status can not be updated' do
+      describe 'and closes the discussion' do
         before { discussion.update_status!(:closed, initiator) }
 
-        it { expect(discussion.status).to eq :opened }
+        it { expect(discussion.status).to eq :closed }
         it { expect(discussion.reachable_statuses_for initiator).to eq [] }
-        it { expect(discussion.reachable_statuses_for moderator).to eq [:closed] }
+        it { expect(discussion.reachable_statuses_for moderator).to eq [:opened, :solved] }
         it { expect(discussion.reachable_statuses_for student).to eq [] }
-        it { expect(discussion.commentable_by? student).to be true }
+        it { expect(discussion.commentable_by? student).to be false }
+        it { expect(discussion.commentable_by? moderator).to be true }
+      end
+
+      describe 'and submits a valid solution' do
+        before { stub_runner! status: :passed, result: 'passed!' }
+        before { problem.submit_solution!(initiator, content: 'x = 2') }
+        before { discussion.reload }
+
+        it { expect(discussion.status).to eq :closed }
+        it { expect(discussion.reachable_statuses_for initiator).to eq [] }
+        it { expect(discussion.reachable_statuses_for moderator).to eq [:opened, :solved] }
+        it { expect(discussion.reachable_statuses_for student).to eq [] }
+        it { expect(discussion.commentable_by? student).to be false }
         it { expect(discussion.commentable_by? moderator).to be true }
       end
     end
 
-    describe 'receive message from helper' do
+    describe 'receive message from another student' do
       before { discussion.submit_message!({content: 'You should do this'}, student) }
 
       it { expect(discussion.has_responses?).to be true }
+      it { expect(discussion.has_validated_responses?).to be false }
       it { expect(initiator.unread_discussions).to include discussion }
       it { expect(discussion.messages.first.content).to eq 'You should do this' }
-      it { expect(discussion.reachable_statuses_for initiator).to eq [] }
+      it { expect(discussion.reachable_statuses_for initiator).to eq [:closed] }
       it { expect(discussion.reachable_statuses_for moderator).to eq [:closed, :solved] }
       it { expect(discussion.reachable_statuses_for student).to eq [] }
       it { expect(student.subscribed_to? discussion).to be true }
 
-      describe 'gets updated to pending_review by initiator but he can not do it' do
+      describe 'gets updated to pending_review by initiator but it can not do it' do
+        it { expect { discussion.update_status!(:pending_review, initiator) }.not_to change(discussion, :status) }
+      end
+
+      describe 'initiator tries to solve it' do
+        it { expect { discussion.update_status!(:solved, initiator) }.not_to change(discussion, :status) }
+      end
+
+      describe 'gets solved by moderator' do
+        before { discussion.update_status!(:solved, moderator) }
+
+        it { expect(discussion.status).to eq :solved }
+        it { expect(discussion.reachable_statuses_for initiator).to eq [] }
+        it { expect(discussion.reachable_statuses_for moderator).to eq [:opened, :closed] }
+        it { expect(discussion.reachable_statuses_for student).to eq [] }
+        it { expect(discussion.commentable_by? student).to be false }
+        it { expect(discussion.commentable_by? moderator).to be true }
+      end
+
+      describe 'and submits a valid solution' do
+        before { stub_runner! status: :passed, result: 'passed!' }
+        before { problem.submit_solution!(initiator, content: 'x = 2') }
+        before { discussion.reload }
+
+        it { expect(discussion.status).to eq :closed }
+      end
+
+      describe 'and that message gets approved' do
+        before { discussion.messages.last.update! approved: true }
+        before { discussion.reload }
+
+        it { expect(discussion.has_validated_responses?).to be true }
+
+        describe 'and submits a valid solution' do
+          before { stub_runner! status: :passed, result: 'passed!' }
+          before { problem.submit_solution!(initiator, content: 'x = 2') }
+          before { discussion.reload }
+
+          it { expect(discussion.status).to eq :pending_review }
+        end
+      end
+    end
+
+    describe 'receives message from a moderator' do
+      before { discussion.submit_message!({content: 'I suggest doing this'}, moderator) }
+      before { discussion.reload }
+
+      it { expect(discussion.has_responses?).to be true }
+      it { expect(discussion.has_validated_responses?).to be true }
+      it { expect(initiator.unread_discussions).to include discussion }
+      it { expect(discussion.messages.last.content).to eq 'I suggest doing this' }
+      it { expect(discussion.reachable_statuses_for initiator).to eq [:pending_review] }
+      it { expect(discussion.reachable_statuses_for moderator).to eq [:closed, :solved] }
+      it { expect(discussion.reachable_statuses_for student).to eq [] }
+      it { expect(moderator.subscribed_to? discussion).to be true }
+
+      describe 'gets updated to pending_review by initiator' do
         before { discussion.update_status!(:pending_review, initiator) }
 
-        it { expect(discussion.status).to eq :opened }
+        it { expect(discussion.status).to eq :pending_review }
         it { expect(discussion.reachable_statuses_for initiator).to eq [] }
-        it { expect(discussion.reachable_statuses_for moderator).to eq [:closed, :solved] }
+        it { expect(discussion.reachable_statuses_for moderator).to eq [:opened, :closed, :solved] }
         it { expect(discussion.reachable_statuses_for student).to eq [] }
-        it { expect(discussion.commentable_by? student).to be true }
+        it { expect(discussion.commentable_by? student).to be false }
         it { expect(discussion.commentable_by? moderator).to be true }
+      end
+
+      describe 'and submits a valid solution' do
+        before { stub_runner! status: :passed, result: 'passed!' }
+        before { problem.submit_solution!(initiator, content: 'x = 2') }
+        before { discussion.reload }
+
+        it { expect(discussion.status).to eq :pending_review }
       end
 
       describe 'initiator tries to solve it' do
@@ -83,6 +163,8 @@ describe Discussion, organization_workspace: :test do
       end
     end
   end
+
+
 
   describe '#toggle_subscription!' do
     let(:discussion) { create(:discussion, {organization: Organization.current}) }
@@ -164,11 +246,12 @@ describe Discussion, organization_workspace: :test do
   describe 'messages not being deleted' do
     let(:user) { create(:user) }
     let(:other_user) { create(:user) }
-    let(:problem) { create(:problem) }
+    let(:problem) { create(:indexed_exercise) }
     let(:assignment) { problem.submit_solution! user }
     let(:discussion) { problem.discuss!(user, {title: 'A discussion'}) }
 
     before { discussion.submit_message!({content: 'You should do this'}, user) }
+    before { stub_runner! status: :passed, result: 'passed!' }
     before { problem.submit_solution! other_user }
 
     it { expect(discussion.messages.count).to eq 1 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,7 +51,27 @@ def reindex_current_organization!
   reindex_organization! Organization.current
 end
 
+# ===============
+# Runner stubbing
+# ===============
+
+Language.class_eval do
+  patch :run_tests! do |*args, hyper|
+    warn 'You are calling Language#run_tests! which will perform a network hit. This is slow and unexpected things will happen if you do in a test context'
+    warn 'Please use `stub_runner!` to avoid this and properly setup your expectations'
+    warn 'Called from: '
+    warn caller.grep /academia/
+    warn ''
+    hyper.call
+  end
+end
+
+def stub_runner!(stubbed_response)
+  allow_any_instance_of(Language).to receive(:run_tests!).and_return stubbed_response
+end
+
 SimpleCov.start
 
 # shibi 「死び」 is the ghost cousin of kibi 「きび」
 User.configure_buried_profile! first_name: 'shibi', last_name: '', email: 'shibi@mumuki.org'
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,17 +55,6 @@ end
 # Runner stubbing
 # ===============
 
-Language.class_eval do
-  patch :run_tests! do |*args, hyper|
-    warn 'You are calling Language#run_tests! which will perform a network hit. This is slow and unexpected things will happen if you do in a test context'
-    warn 'Please use `stub_runner!` to avoid this and properly setup your expectations'
-    warn 'Called from: '
-    warn caller.grep /academia/
-    warn ''
-    hyper.call
-  end
-end
-
 def stub_runner!(stubbed_response)
   allow_any_instance_of(Language).to receive(:run_tests!).and_return stubbed_response
 end


### PR DESCRIPTION
This PR together with https://github.com/mumuki/mumuki-laboratory/pull/1451 has one main goal: to improve performance on book discussions page. :top: 
It also addresses some minor issues :bug: :

- useful button wasn't being shown as `solved?` was delegated to `submission_status` instead of `discussion`. :+1: 
- a discussion with no moderator response but with another students answers was being marked as `requires_moderator_response: false`. :sos: 
- the discussions weren't being solved because of `reachable_statuses_for_initiator` method deletion. I'm adding it once again and hiding them visually. :rescue_worker_helmet: 
- two locales were mixed up between pt and en translations :england: :brazil: 
- approved is now displayed for non moderator users  :heavy_check_mark: 

Tests are added to ensure none of this cases happen again