### PR TITLE
Feature progress transfer

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -263,6 +263,10 @@ class Assignment < Progress
 
   private
 
+  def duplicates_key
+    { organization: organization, exercise: exercise, submitter: submitter }
+  end
+
   def update_submissions_count!
     self.class.connection.execute(
       "update public.exercises

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -266,7 +266,7 @@ class Assignment < Progress
   private
 
   def duplicates_key
-    { organization: organization, exercise: exercise, submitter: submitter }
+    { exercise: exercise, submitter: submitter }
   end
 
   def update_submissions_count!

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -23,6 +23,8 @@ class Assignment < Progress
 
   delegate :completed?, :solved?, to: :submission_status
 
+  delegate :content_available_in?, to: :parent
+
   alias_attribute :status, :submission_status
   alias_attribute :attempts_count, :attemps_count
 
@@ -282,5 +284,4 @@ class Assignment < Progress
   def update_last_submission!
     submitter.update!(last_submission_date: DateTime.current, last_exercise: exercise)
   end
-
 end

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -97,10 +97,6 @@ class Indicator < Progress
     children.delete_all(:delete_all)
   end
 
-  def has_duplicates?
-    super || children.any?(&:has_duplicates?)
-  end
-
   private
 
   def duplicates_key

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -66,7 +66,17 @@ class Indicator < Progress
     where(content: content, organization: organization).delete_all
   end
 
+  def copy_on(organization)
+    super.tap { |it| it.assign_attributes indicators: indicators_on(organization), assignments: assignments_on(organization) }
+  end
+
   private
+
+  %i(indicators assignments).each do |selector|
+    define_method("#{selector}_on") do |organization|
+      send(selector).map { |it| it.copy_on(organization) }
+    end
+  end
 
   def children
     indicators.presence || assignments

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -97,6 +97,10 @@ class Indicator < Progress
     children.delete_all(:delete_all)
   end
 
+  def content_available_in?(organization)
+    content.usage_in_organization(organization).present?
+  end
+
   private
 
   def duplicates_key

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -87,6 +87,20 @@ class Indicator < Progress
     indicators.each { |it| it.move_children_to!(organization_id) }
   end
 
+  def delete_duplicates!
+    duplicates.each(&:cascade_delete_children!)
+    super
+  end
+
+  def cascade_delete_children!
+    indicators.each(&:cascade_delete_children!)
+    children.delete_all
+  end
+
+  def has_duplicates?
+    super || children.any?(&:has_duplicates?)
+  end
+
   private
 
   def duplicates_key

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -94,7 +94,7 @@ class Indicator < Progress
 
   def cascade_delete_children!
     indicators.each(&:cascade_delete_children!)
-    children.delete_all
+    children.delete_all(:delete_all)
   end
 
   def has_duplicates?

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -92,12 +92,12 @@ class Indicator < Progress
     content.usage_in_organization(organization).present?
   end
 
-  private
-
   def delete_duplicates_in!(organization)
     duplicates_in(organization).each(&:cascade_delete_children!)
     super
   end
+
+  private
 
   def duplicates_key
     { content: content, user: user }

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -72,9 +72,9 @@ class Indicator < Progress
   end
 
   def _copy_to!(organization)
-    copy = super
+    progress_item = super
     children.each { |it| it._copy_to! organization }
-    copy
+    progress_item
   end
 
   def move_children_to!(organization)
@@ -94,13 +94,13 @@ class Indicator < Progress
 
   private
 
-  def delete_duplicates!
-    duplicates.each(&:cascade_delete_children!)
+  def delete_duplicates_in!(organization)
+    duplicates_in(organization).each(&:cascade_delete_children!)
     super
   end
 
   def duplicates_key
-    { organization: organization, content: content, user: user }
+    { content: content, user: user }
   end
 
   def children

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -66,17 +66,17 @@ class Indicator < Progress
     where(content: content, organization: organization).delete_all
   end
 
-  def move_to!(organization)
+  def _move_to!(organization)
     transaction do
       super
       move_children_to!(organization.id)
     end
   end
 
-  def copy_to!(organization)
+  def _copy_to!(organization)
     transaction do
       super
-      children.each { |it| it.copy_to! organization }
+      children.each { |it| it._copy_to! organization }
     end
   end
 

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -66,8 +66,21 @@ class Indicator < Progress
     where(content: content, organization: organization).delete_all
   end
 
+  def move_to!(organization)
+    transaction do
+      super
+      move_children_to!(organization.id)
+    end
+  end
+
   def copy_on(organization)
     super.tap { |it| it.assign_attributes indicators: indicators_on(organization), assignments: assignments_on(organization) }
+  end
+
+  def move_children_to!(organization_id)
+    children.update_all(organization_id: organization_id)
+
+    indicators.each { |it| it.move_children_to!(organization_id) }
   end
 
   private

--- a/app/models/progress.rb
+++ b/app/models/progress.rb
@@ -18,6 +18,7 @@ class Progress < ApplicationRecord
   end
 
   def transfer_to!(organization)
+    raise "Transferred progress' content must be available in destination!" unless content_available_in?(organization)
     relocate_on!(organization)
     save!
     delete_duplicates!

--- a/app/models/progress.rb
+++ b/app/models/progress.rb
@@ -17,16 +17,14 @@ class Progress < ApplicationRecord
     dup.transfer_to!(organization)
   end
 
-  def move_to!(organization)
-    transfer_to!(organization)
-  end
-
   def transfer_to!(organization)
     relocate_on!(organization)
     save!
     delete_duplicates!
     self
   end
+
+  alias_method :move_to!, :transfer_to!
 
   def relocate_on!(organization)
     assign_attributes organization: organization, parent: nil

--- a/app/models/progress.rb
+++ b/app/models/progress.rb
@@ -12,4 +12,12 @@ class Progress < ApplicationRecord
   def dirty_parent_by_submission!
     parent&.dirty_by_submission!
   end
+
+  def copy_to!(organization)
+    copy_on(organization).save!
+  end
+
+  def copy_on(organization)
+    dup.tap { |it| it.assign_attributes organization: organization, parent: nil }
+  end
 end

--- a/app/models/progress.rb
+++ b/app/models/progress.rb
@@ -17,6 +17,10 @@ class Progress < ApplicationRecord
     copy_on(organization).save!
   end
 
+  def move_to!(organization)
+    update! organization: organization, parent: nil
+  end
+
   def copy_on(organization)
     dup.tap { |it| it.assign_attributes organization: organization, parent: nil }
   end

--- a/app/models/progress.rb
+++ b/app/models/progress.rb
@@ -14,14 +14,33 @@ class Progress < ApplicationRecord
   end
 
   def copy_to!(organization)
-    copy_on(organization).save!
+    dup.transfer_to!(organization)
   end
 
   def move_to!(organization)
-    update! organization: organization, parent: nil
+    transfer_to!(organization)
   end
 
-  def copy_on(organization)
-    dup.tap { |it| it.assign_attributes organization: organization, parent: nil }
+  def transfer_to!(organization)
+    relocate_on!(organization)
+    save!
+    delete_duplicates!
+    self
+  end
+
+  def relocate_on!(organization)
+    assign_attributes organization: organization, parent: nil
+  end
+
+  def duplicates
+    self.class.where(duplicates_key).where.not(id: id)
+  end
+
+  def has_duplicates?
+    duplicates.present?
+  end
+
+  def delete_duplicates!
+    duplicates.delete_all
   end
 end

--- a/lib/mumuki/domain.rb
+++ b/lib/mumuki/domain.rb
@@ -38,6 +38,7 @@ require_relative './domain/workspace'
 require_relative './domain/helpers'
 require_relative './domain/syncable'
 require_relative './domain/store'
+require_relative './domain/progress_transfer'
 
 class Mumukit::Assistant
   def self.valid?(rules)

--- a/lib/mumuki/domain/progress_transfer.rb
+++ b/lib/mumuki/domain/progress_transfer.rb
@@ -1,0 +1,8 @@
+module Mumuki::Domain
+  module ProgressTransfer
+  end
+end
+
+require_relative './progress_transfer/base'
+require_relative './progress_transfer/move'
+require_relative './progress_transfer/copy'

--- a/lib/mumuki/domain/progress_transfer/base.rb
+++ b/lib/mumuki/domain/progress_transfer/base.rb
@@ -1,0 +1,44 @@
+class Mumuki::Domain::ProgressTransfer::Base
+  attr_reader *%i(source_organization destination_organization progress_item transferred_item)
+
+  delegate :user, to: :progress_item
+
+  def initialize(progress_item, destination_organization)
+    @progress_item = progress_item
+    @destination_organization = destination_organization
+  end
+
+  def execute!
+    ActiveRecord::Base.transaction do
+      pre_transfer!
+      transfer!
+      post_transfer!
+    end
+  end
+
+  def pre_transfer!
+    validate_transferrable!
+    @source_organization = progress_item.organization
+    progress_item.delete_duplicates_in!(destination_organization)
+  end
+
+  def transfer!
+    @transferred_item = do_transfer!
+  end
+
+  def post_transfer!
+    transferred_item.dirty_parent_by_submission!
+    notify_transfer!
+    transferred_item
+  end
+
+  def validate_transferrable!
+    raise "Transferred progress' content must be available in destination!" unless progress_item.content_available_in?(destination_organization)
+    raise 'User must be student in destination organization' unless user.student_granted_organizations.include?(destination_organization)
+    raise 'Transfer only supported for guide indicators' unless progress_item.guide_indicator?
+  end
+
+  def notify_transfer!
+    Mumukit::Nuntius.notify! 'progress-transfers', { from: source_organization.name, to: destination_organization.name, item_type: progress_item.class.to_s, item_id: progress_item.id, transfer_type: transfer_type }
+  end
+end

--- a/lib/mumuki/domain/progress_transfer/base.rb
+++ b/lib/mumuki/domain/progress_transfer/base.rb
@@ -39,6 +39,6 @@ class Mumuki::Domain::ProgressTransfer::Base
   end
 
   def notify_transfer!
-    Mumukit::Nuntius.notify! 'progress-transfers', { from: source_organization.name, to: destination_organization.name, item_type: progress_item.class.to_s, item_id: progress_item.id, transfer_type: transfer_type }
+    Mumukit::Nuntius.notify! 'progress-transfers', { from: source_organization.name, to: destination_organization.name, item_type: transferred_item.class.to_s, item_id: transferred_item.id, transfer_type: transfer_type }
   end
 end

--- a/lib/mumuki/domain/progress_transfer/base.rb
+++ b/lib/mumuki/domain/progress_transfer/base.rb
@@ -34,7 +34,7 @@ class Mumuki::Domain::ProgressTransfer::Base
 
   def validate_transferrable!
     raise "Transferred progress' content must be available in destination!" unless progress_item.content_available_in?(destination_organization)
-    raise 'User must be student in destination organization' unless user.student_granted_organizations.include?(destination_organization)
+    raise 'User must be student in destination organization' unless user.student_of?(destination_organization)
     raise 'Transfer only supported for guide indicators' unless progress_item.guide_indicator?
   end
 

--- a/lib/mumuki/domain/progress_transfer/copy.rb
+++ b/lib/mumuki/domain/progress_transfer/copy.rb
@@ -1,0 +1,9 @@
+class Mumuki::Domain::ProgressTransfer::Copy < Mumuki::Domain::ProgressTransfer::Base
+  def transfer_type
+    :copy
+  end
+
+  def do_transfer!
+    progress_item._copy_to!(destination_organization)
+  end
+end

--- a/lib/mumuki/domain/progress_transfer/move.rb
+++ b/lib/mumuki/domain/progress_transfer/move.rb
@@ -1,0 +1,14 @@
+class Mumuki::Domain::ProgressTransfer::Move < Mumuki::Domain::ProgressTransfer::Base
+  def transfer_type
+    :move
+  end
+
+  def pre_transfer!
+    super
+    progress_item.dirty_parent_by_submission!
+  end
+
+  def do_transfer!
+    progress_item._move_to!(destination_organization)
+  end
+end

--- a/lib/mumuki/domain/status/submission/submission.rb
+++ b/lib/mumuki/domain/status/submission/submission.rb
@@ -50,4 +50,8 @@ module Mumuki::Domain::Status::Submission
   def exp_given
     0
   end
+
+  def dup
+    self
+  end
 end

--- a/spec/models/progress_spec.rb
+++ b/spec/models/progress_spec.rb
@@ -135,12 +135,12 @@ describe Progress do
 
         # orga1: G1, T, B
         # orga2: G1, G2, T, B
-        it { expect(Indicator.count).to eq 7 }
-        it { expect(Assignment.count).to eq 4 }
+        pending { expect(Indicator.count).to eq 7 }
+        pending { expect(Assignment.count).to eq 4 }
 
-        it { expect(post_transfer_orga1_progress).to json_like pre_transfer_orga1_progress }
+        pending { expect(post_transfer_orga1_progress).to json_like pre_transfer_orga1_progress }
 
-        it { expect(post_transfer_orga2_progress).to json_like({name: 'book-1',
+        pending { expect(post_transfer_orga2_progress).to json_like({name: 'book-1',
                                                                 organization: 'orga-2',
                                                                 type: 'Book',
                                                                 children: [
@@ -165,21 +165,21 @@ describe Progress do
                                                                       ]}]}]}) }
 
         context 'before triggering indicator recalculation' do
-          it { expect(guide1.progress_for(user, orga2).dirty_by_submission).to be true }
-          it { expect(topic.progress_for(user, orga2).dirty_by_submission).to be true }
-          it { expect(book.progress_for(user, orga2).dirty_by_submission).to be true }
+          pending { expect(guide1.progress_for(user, orga2).dirty_by_submission).to be true }
+          pending { expect(topic.progress_for(user, orga2).dirty_by_submission).to be true }
+          pending { expect(book.progress_for(user, orga2).dirty_by_submission).to be true }
         end
 
         context 'after triggering indicator recalculation' do
           before { book.progress_for(user, orga2).completed? }
 
-          it { expect(book.progress_for(user, orga2).completed?).to be false }
-          it { expect(guide1.progress_for(user, orga2).dirty_by_submission).to be false }
-          it { expect(guide1.progress_for(user, orga2).send(:children_passed_count)).to be 1 }
-          it { expect(topic.progress_for(user, orga2).dirty_by_submission).to be false }
-          it { expect(topic.progress_for(user, orga2).send(:children_passed_count)).to be 0 }
-          it { expect(book.progress_for(user, orga2).dirty_by_submission).to be false }
-          it { expect(book.progress_for(user, orga2).send(:children_passed_count)).to be 0 }
+          pending { expect(book.progress_for(user, orga2).completed?).to be false }
+          pending { expect(guide1.progress_for(user, orga2).dirty_by_submission).to be false }
+          pending { expect(guide1.progress_for(user, orga2).send(:children_passed_count)).to be 1 }
+          pending { expect(topic.progress_for(user, orga2).dirty_by_submission).to be false }
+          pending { expect(topic.progress_for(user, orga2).send(:children_passed_count)).to be 0 }
+          pending { expect(book.progress_for(user, orga2).dirty_by_submission).to be false }
+          pending { expect(book.progress_for(user, orga2).send(:children_passed_count)).to be 0 }
         end
       end
 
@@ -242,14 +242,14 @@ describe Progress do
 
         # orga1: G1, T, B
         # orga2: G1, T, B
-        it { expect(Indicator.count).to eq 6 }
-        it { expect(Assignment.count).to eq 4 }
+        pending { expect(Indicator.count).to eq 6 }
+        pending { expect(Assignment.count).to eq 4 }
 
-        it { expect { guide2_indicator.reload }.to raise_error(ActiveRecord::RecordNotFound) }
+        pending { expect { guide2_indicator.reload }.to raise_error(ActiveRecord::RecordNotFound) }
 
-        it { expect(post_transfer_orga1_progress).to json_like pre_transfer_orga1_progress }
+        pending { expect(post_transfer_orga1_progress).to json_like pre_transfer_orga1_progress }
 
-        it { expect(post_transfer_orga2_progress).to json_like({name: 'book-1',
+        pending { expect(post_transfer_orga2_progress).to json_like({name: 'book-1',
                                                                 organization: 'orga-2',
                                                                 type: 'Book',
                                                                 children: [
@@ -273,10 +273,10 @@ describe Progress do
       context 'on moving assignment' do
         before { assignment1.move_to!(orga2) }
 
-        it { expect(Indicator.count).to eq 7 }
-        it { expect(Assignment.count).to eq 3 }
+        pending { expect(Indicator.count).to eq 7 }
+        pending { expect(Assignment.count).to eq 3 }
 
-        it { expect(post_transfer_orga1_progress).to json_like({name: 'book-1',
+        pending { expect(post_transfer_orga1_progress).to json_like({name: 'book-1',
                                                                organization: 'orga-1',
                                                                type: 'Book',
                                                                children: [{
@@ -291,7 +291,7 @@ describe Progress do
                                                                                            { name: 'exercise-2', organization: 'orga-1', solution: 'bar', type: 'Assignment' }
                                                                                          ]}]}]}) }
 
-        it { expect(post_transfer_orga2_progress).to json_like({name: 'book-1',
+        pending { expect(post_transfer_orga2_progress).to json_like({name: 'book-1',
                                                                 organization: 'orga-2',
                                                                 type: 'Book',
                                                                 children: [
@@ -361,17 +361,17 @@ describe Progress do
         let!(:guide2_indicator) { guide2.progress_for(user, orga2) }
         before { topic.progress_for(user, orga1).move_to!(orga2) }
 
-        it { expect(Indicator.count).to eq 4 }
-        it { expect(Assignment.count).to eq 2 }
+        pending { expect(Indicator.count).to eq 4 }
+        pending { expect(Assignment.count).to eq 2 }
 
-        it { expect { guide2_indicator.reload }.to raise_error(ActiveRecord::RecordNotFound) }
+        pending { expect { guide2_indicator.reload }.to raise_error(ActiveRecord::RecordNotFound) }
 
-        it { expect(post_transfer_orga1_progress).to json_like({name: 'book-1',
+        pending { expect(post_transfer_orga1_progress).to json_like({name: 'book-1',
                                                                 organization: 'orga-1',
                                                                 type: 'Book',
                                                                 children: []}) }
 
-        it { expect(post_transfer_orga2_progress).to json_like({name: 'book-1',
+        pending { expect(post_transfer_orga2_progress).to json_like({name: 'book-1',
                                                                 organization: 'orga-2',
                                                                 type: 'Book',
                                                                 children: [

--- a/spec/models/progress_spec.rb
+++ b/spec/models/progress_spec.rb
@@ -3,27 +3,61 @@ require 'spec_helper'
 describe Progress do
   let(:user) { create :user }
 
-  let!(:orga1) { create :organization, name: 'orga-1', book: book1 }
-  let!(:orga2) { create :organization, name: 'orga-2', book: book1 }
-  let(:book1) { create :book, name: 'book-1', chapters: [create(:chapter, topic: topic)] }
-  let(:book2) { create :book }
+  # Organizations. Same content for each one
+  let!(:orga1) { create :organization, name: 'orga-1', book: book }
+  let!(:orga2) { create :organization, name: 'orga-2', book: book }
+
+  # Empty book to test content validation on destination
+  let(:empty_book) { create :book }
+
+  # Main content tree
+  #     B
+  #     |
+  #     T
+  #   /  \
+  #  G1   G2
+  # |  \    \
+  # E1  E2  E3
+  let(:book) { create :book, name: 'book-1', chapters: [create(:chapter, topic: topic)] }
+
   let(:topic) { create :topic, name: 'topic-1', lessons: [create(:lesson, guide: guide1), create(:lesson, guide: guide2)] }
+
   let(:guide1) { create :guide, name: 'guide-1', exercises: [exercise1, exercise2] }
   let(:guide2) { create :guide, name: 'guide-2', exercises: [exercise3] }
+
   let(:exercise1) { create :exercise, name: 'exercise-1' }
   let(:exercise2) { create :exercise, name: 'exercise-2' }
   let(:exercise3) { create :exercise, name: 'exercise-3' }
 
+  # Progress tree for orga1
+  #     IB (0/1)
+  #     |
+  #     IT (1/2)
+  #     |
+  #    IG1 (2/2)
+  #   /  \
+  #  A1✔ A2✔
+
   before { orga1.switch! }
   let!(:assignment1) { exercise1.submit_solution!(user, content: 'foo').tap(&:passed!) }
   let!(:assignment2) { exercise2.submit_solution!(user, content: 'bar').tap(&:passed!) }
+
+  # Progress tree for orga2
+  #     IB (0/1)
+  #     |
+  #     IT (0/2)
+  #     |
+  #    IG2 (0/1)
+  #     |
+  #    A3 X
+
   before { orga2.switch! }
   let!(:assignment3) { exercise3.submit_solution!(user, content: 'baz').tap(&:failed!) }
 
-  let!(:pre_transfer_orga1_progress) { jsonify(book1.progress_for(user, orga1)) }
-  let!(:pre_transfer_orga2_progress) { jsonify(book1.progress_for(user, orga2)) }
-  let(:post_transfer_orga1_progress) { jsonify(book1.progress_for(user, orga1)) }
-  let(:post_transfer_orga2_progress) { jsonify(book1.progress_for(user, orga2)) }
+  let!(:pre_transfer_orga1_progress) { jsonify(book.progress_for(user, orga1)) }
+  let!(:pre_transfer_orga2_progress) { jsonify(book.progress_for(user, orga2)) }
+  let(:post_transfer_orga1_progress) { jsonify(book.progress_for(user, orga1)) }
+  let(:post_transfer_orga2_progress) { jsonify(book.progress_for(user, orga2)) }
 
   def jsonify(progress_item)
     case progress_item
@@ -46,6 +80,8 @@ describe Progress do
 
   describe 'progress transfer' do
     context 'before transfer' do
+      # orga1: G1, T, B
+      # orga2: G2, T, B
       it { expect(Indicator.count).to eq 6 }
       it { expect(Assignment.count).to eq 3 }
 
@@ -82,15 +118,17 @@ describe Progress do
     end
 
     context 'it disallows transfer when content not in destination orga' do
-      before { orga1.update! book: book2 }
+      before { orga1.update! book: empty_book }
 
-      it { expect { book2.progress_for(user, orga1).copy_to!(orga2) }.to raise_error "Transferred progress' content must be available in destination!" }
+      it { expect { empty_book.progress_for(user, orga1).copy_to!(orga2) }.to raise_error "Transferred progress' content must be available in destination!" }
     end
 
     describe 'copy_to!' do
       context 'on copying assignment' do
         before { assignment1.copy_to!(orga2) }
 
+        # orga1: G1, T, B
+        # orga2: G1, G2, T, B
         it { expect(Indicator.count).to eq 7 }
         it { expect(Assignment.count).to eq 4 }
 
@@ -119,11 +157,31 @@ describe Progress do
                                                                         children: [
                                                                           { name: 'exercise-3', organization: 'orga-2', solution: 'baz', type: 'Assignment' }
                                                                       ]}]}]}) }
+
+        context 'before triggering indicator recalculation' do
+          it { expect(guide1.progress_for(user, orga2).dirty_by_submission).to be true }
+          it { expect(topic.progress_for(user, orga2).dirty_by_submission).to be true }
+          it { expect(book.progress_for(user, orga2).dirty_by_submission).to be true }
+        end
+
+        context 'after triggering indicator recalculation' do
+          before { book.progress_for(user, orga2).completed? }
+
+          it { expect(book.progress_for(user, orga2).completed?).to be false }
+          it { expect(guide1.progress_for(user, orga2).dirty_by_submission).to be false }
+          it { expect(guide1.progress_for(user, orga2).send(:children_passed_count)).to be 1 }
+          it { expect(topic.progress_for(user, orga2).dirty_by_submission).to be false }
+          it { expect(topic.progress_for(user, orga2).send(:children_passed_count)).to be 0 }
+          it { expect(book.progress_for(user, orga2).dirty_by_submission).to be false }
+          it { expect(book.progress_for(user, orga2).send(:children_passed_count)).to be 0 }
+        end
       end
 
       context 'on copying guide' do
         before { guide1.progress_for(user, orga1).copy_to!(orga2) }
 
+        # orga1: G1, T, B
+        # orga2: G1, G2, T, B
         it { expect(Indicator.count).to eq 7 }
         it { expect(Assignment.count).to eq 5 }
 
@@ -153,12 +211,31 @@ describe Progress do
                                                                         children: [
                                                                           { name: 'exercise-3', organization: 'orga-2', solution: 'baz', type: 'Assignment' }
                                                                         ]}]}]}) }
+        context 'before triggering indicator recalculation' do
+          it { expect(guide1.progress_for(user, orga2).dirty_by_submission).to be true }
+          it { expect(topic.progress_for(user, orga2).dirty_by_submission).to be true }
+          it { expect(book.progress_for(user, orga2).dirty_by_submission).to be true }
+        end
+
+        context 'after triggering indicator recalculation' do
+          before { book.progress_for(user, orga2).completed? }
+
+          it { expect(book.progress_for(user, orga2).completed?).to be false }
+          it { expect(guide1.progress_for(user, orga2).dirty_by_submission).to be false }
+          it { expect(guide1.progress_for(user, orga2).send(:children_passed_count)).to be 2 }
+          it { expect(topic.progress_for(user, orga2).dirty_by_submission).to be false }
+          it { expect(topic.progress_for(user, orga2).send(:children_passed_count)).to be 1 }
+          it { expect(book.progress_for(user, orga2).dirty_by_submission).to be false }
+          it { expect(book.progress_for(user, orga2).send(:children_passed_count)).to be 0 }
+        end
       end
 
       context 'on copying topic' do
         let!(:guide2_indicator) { guide2.progress_for(user, orga2) }
         before { topic.progress_for(user, orga1).copy_to!(orga2) }
 
+        # orga1: G1, T, B
+        # orga2: G1, T, B
         it { expect(Indicator.count).to eq 6 }
         it { expect(Assignment.count).to eq 4 }
 

--- a/spec/models/progress_spec.rb
+++ b/spec/models/progress_spec.rb
@@ -1,0 +1,304 @@
+require 'spec_helper'
+
+describe Progress do
+  let(:user) { create :user }
+
+  let!(:orga1) { create :organization, name: 'orga-1', book: book }
+  let!(:orga2) { create :organization, name: 'orga-2', book: book }
+  let(:book) { create :book, name: 'book-1', chapters: [create(:chapter, topic: topic)] }
+  let(:topic) { create :topic, name: 'topic-1', lessons: [create(:lesson, guide: guide1), create(:lesson, guide: guide2)] }
+  let(:guide1) { create :guide, name: 'guide-1', exercises: [exercise1, exercise2] }
+  let(:guide2) { create :guide, name: 'guide-2', exercises: [exercise3] }
+  let(:exercise1) { create :exercise, name: 'exercise-1' }
+  let(:exercise2) { create :exercise, name: 'exercise-2' }
+  let(:exercise3) { create :exercise, name: 'exercise-3' }
+
+  before { orga1.switch! }
+  let!(:assignment1) { exercise1.submit_solution!(user, content: 'foo').tap(&:passed!) }
+  let!(:assignment2) { exercise2.submit_solution!(user, content: 'bar').tap(&:passed!) }
+  before { orga2.switch! }
+  let!(:assignment3) { exercise3.submit_solution!(user, content: 'baz').tap(&:failed!) }
+
+  let!(:pre_transfer_orga1_progress) { jsonify(book.progress_for(user, orga1)) }
+  let!(:pre_transfer_orga2_progress) { jsonify(book.progress_for(user, orga2)) }
+  let(:post_transfer_orga1_progress) { jsonify(book.progress_for(user, orga1)) }
+  let(:post_transfer_orga2_progress) { jsonify(book.progress_for(user, orga2)) }
+
+  def jsonify(progress_item)
+    case progress_item
+    when Indicator
+      {
+        children: progress_item.send(:children).map { |it| jsonify(it) }.sort_by { |it| it[:name] },
+        name: progress_item.content.name,
+        organization: progress_item.organization.name,
+        type: progress_item.content_type
+      }
+      else
+      {
+        name: progress_item.exercise.name,
+        organization: progress_item.organization.name,
+        solution: progress_item.solution,
+        type: 'Assignment'
+      }
+    end
+  end
+
+  describe 'progress transfer' do
+    context 'before transfer' do
+      it { expect(Indicator.count).to eq 6 }
+      it { expect(Assignment.count).to eq 3 }
+
+      it { expect(pre_transfer_orga1_progress).to json_like({name: 'book-1',
+                                                             organization: 'orga-1',
+                                                             type: 'Book',
+                                                             children: [{
+                                                               name: 'topic-1',
+                                                               organization: 'orga-1',
+                                                               type: 'Topic',
+                                                               children: [{
+                                                                 name: 'guide-1',
+                                                                 organization: 'orga-1',
+                                                                 type: 'Guide',
+                                                                 children: [
+                                                                   { name: 'exercise-1', organization: 'orga-1', solution: 'foo', type: 'Assignment' },
+                                                                   { name: 'exercise-2', organization: 'orga-1', solution: 'bar', type: 'Assignment' }
+                                                                 ]}]}]}) }
+
+      it { expect(pre_transfer_orga2_progress).to json_like({name: 'book-1',
+                                                             organization: 'orga-2',
+                                                             type: 'Book',
+                                                             children: [{
+                                                               name: 'topic-1',
+                                                               organization: 'orga-2',
+                                                               type: 'Topic',
+                                                               children: [{
+                                                                 name: 'guide-2',
+                                                                 organization: 'orga-2',
+                                                                 type: 'Guide',
+                                                                 children: [
+                                                                   { name: 'exercise-3', organization: 'orga-2', solution: 'baz', type: 'Assignment' }
+                                                                 ]}]}]}) }
+    end
+
+    describe 'copy_to!' do
+      context 'on copying assignment' do
+        before { assignment1.copy_to!(orga2) }
+
+        it { expect(Indicator.count).to eq 7 }
+        it { expect(Assignment.count).to eq 4 }
+
+        it { expect(post_transfer_orga1_progress).to json_like pre_transfer_orga1_progress }
+
+        it { expect(post_transfer_orga2_progress).to json_like({name: 'book-1',
+                                                                organization: 'orga-2',
+                                                                type: 'Book',
+                                                                children: [
+                                                                  {
+                                                                    name: 'topic-1',
+                                                                    organization: 'orga-2',
+                                                                    type: 'Topic',
+                                                                    children: [
+                                                                      {
+                                                                        name: 'guide-1',
+                                                                        organization: 'orga-2',
+                                                                        type: 'Guide',
+                                                                        children: [
+                                                                          { name: 'exercise-1', organization: 'orga-2', solution: 'foo', type: 'Assignment' }
+                                                                        ]},
+                                                                      {
+                                                                        name: 'guide-2',
+                                                                        organization: 'orga-2',
+                                                                        type: 'Guide',
+                                                                        children: [
+                                                                          { name: 'exercise-3', organization: 'orga-2', solution: 'baz', type: 'Assignment' }
+                                                                      ]}]}]}) }
+      end
+
+      context 'on copying guide' do
+        before { guide1.progress_for(user, orga1).copy_to!(orga2) }
+
+        it { expect(Indicator.count).to eq 7 }
+        it { expect(Assignment.count).to eq 5 }
+
+        it { expect(post_transfer_orga1_progress).to json_like pre_transfer_orga1_progress }
+
+        it { expect(post_transfer_orga2_progress).to json_like({name: 'book-1',
+                                                                organization: 'orga-2',
+                                                                type: 'Book',
+                                                                children: [
+                                                                  {
+                                                                    name: 'topic-1',
+                                                                    organization: 'orga-2',
+                                                                    type: 'Topic',
+                                                                    children: [
+                                                                      {
+                                                                        name: 'guide-1',
+                                                                        organization: 'orga-2',
+                                                                        type: 'Guide',
+                                                                        children: [
+                                                                          { name: 'exercise-1', organization: 'orga-2', solution: 'foo', type: 'Assignment' },
+                                                                          { name: 'exercise-2', organization: 'orga-2', solution: 'bar', type: 'Assignment' }
+                                                                        ]},
+                                                                      {
+                                                                        name: 'guide-2',
+                                                                        organization: 'orga-2',
+                                                                        type: 'Guide',
+                                                                        children: [
+                                                                          { name: 'exercise-3', organization: 'orga-2', solution: 'baz', type: 'Assignment' }
+                                                                        ]}]}]}) }
+      end
+
+      context 'on copying topic' do
+        let!(:guide2_indicator) { guide2.progress_for(user, orga2) }
+        before { topic.progress_for(user, orga1).copy_to!(orga2) }
+
+        it { expect(Indicator.count).to eq 6 }
+        it { expect(Assignment.count).to eq 4 }
+
+        it { expect { guide2_indicator.reload }.to raise_error(ActiveRecord::RecordNotFound) }
+
+        it { expect(post_transfer_orga1_progress).to json_like pre_transfer_orga1_progress }
+
+        it { expect(post_transfer_orga2_progress).to json_like({name: 'book-1',
+                                                                organization: 'orga-2',
+                                                                type: 'Book',
+                                                                children: [
+                                                                  {
+                                                                    name: 'topic-1',
+                                                                    organization: 'orga-2',
+                                                                    type: 'Topic',
+                                                                    children: [
+                                                                      {
+                                                                        name: 'guide-1',
+                                                                        organization: 'orga-2',
+                                                                        type: 'Guide',
+                                                                        children: [
+                                                                          { name: 'exercise-1', organization: 'orga-2', solution: 'foo', type: 'Assignment' },
+                                                                          { name: 'exercise-2', organization: 'orga-2', solution: 'bar', type: 'Assignment' }
+                                                                        ]}]}]}) }
+      end
+    end
+
+    describe 'move_to!' do
+      context 'on moving assignment' do
+        before { assignment1.move_to!(orga2) }
+
+        it { expect(Indicator.count).to eq 7 }
+        it { expect(Assignment.count).to eq 3 }
+
+        it { expect(post_transfer_orga1_progress).to json_like({name: 'book-1',
+                                                               organization: 'orga-1',
+                                                               type: 'Book',
+                                                               children: [{
+                                                                            name: 'topic-1',
+                                                                            organization: 'orga-1',
+                                                                            type: 'Topic',
+                                                                            children: [{
+                                                                                         name: 'guide-1',
+                                                                                         organization: 'orga-1',
+                                                                                         type: 'Guide',
+                                                                                         children: [
+                                                                                           { name: 'exercise-2', organization: 'orga-1', solution: 'bar', type: 'Assignment' }
+                                                                                         ]}]}]}) }
+
+        it { expect(post_transfer_orga2_progress).to json_like({name: 'book-1',
+                                                                organization: 'orga-2',
+                                                                type: 'Book',
+                                                                children: [
+                                                                  {
+                                                                    name: 'topic-1',
+                                                                    organization: 'orga-2',
+                                                                    type: 'Topic',
+                                                                    children: [
+                                                                      {
+                                                                        name: 'guide-1',
+                                                                        organization: 'orga-2',
+                                                                        type: 'Guide',
+                                                                        children: [
+                                                                          { name: 'exercise-1', organization: 'orga-2', solution: 'foo', type: 'Assignment' }
+                                                                        ]},
+                                                                      {
+                                                                        name: 'guide-2',
+                                                                        organization: 'orga-2',
+                                                                        type: 'Guide',
+                                                                        children: [
+                                                                          { name: 'exercise-3', organization: 'orga-2', solution: 'baz', type: 'Assignment' }
+                                                                        ]}]}]}) }
+      end
+
+      context 'on moving guide' do
+        before { guide1.progress_for(user, orga1).move_to!(orga2) }
+
+        it { expect(Indicator.count).to eq 6 }
+        it { expect(Assignment.count).to eq 3 }
+
+        it { expect(post_transfer_orga1_progress).to json_like({name: 'book-1',
+                                                                organization: 'orga-1',
+                                                                type: 'Book',
+                                                                children: [{
+                                                                             name: 'topic-1',
+                                                                             organization: 'orga-1',
+                                                                             type: 'Topic',
+                                                                             children: []}]}) }
+
+        it { expect(post_transfer_orga2_progress).to json_like({name: 'book-1',
+                                                                organization: 'orga-2',
+                                                                type: 'Book',
+                                                                children: [
+                                                                  {
+                                                                    name: 'topic-1',
+                                                                    organization: 'orga-2',
+                                                                    type: 'Topic',
+                                                                    children: [
+                                                                      {
+                                                                        name: 'guide-1',
+                                                                        organization: 'orga-2',
+                                                                        type: 'Guide',
+                                                                        children: [
+                                                                          { name: 'exercise-1', organization: 'orga-2', solution: 'foo', type: 'Assignment' },
+                                                                          { name: 'exercise-2', organization: 'orga-2', solution: 'bar', type: 'Assignment' }
+                                                                        ]},
+                                                                      {
+                                                                        name: 'guide-2',
+                                                                        organization: 'orga-2',
+                                                                        type: 'Guide',
+                                                                        children: [
+                                                                          { name: 'exercise-3', organization: 'orga-2', solution: 'baz', type: 'Assignment' }
+                                                                        ]}]}]}) }
+      end
+
+      context 'on moving topic' do
+        let!(:guide2_indicator) { guide2.progress_for(user, orga2) }
+        before { topic.progress_for(user, orga1).move_to!(orga2) }
+
+        it { expect(Indicator.count).to eq 4 }
+        it { expect(Assignment.count).to eq 2 }
+
+        it { expect { guide2_indicator.reload }.to raise_error(ActiveRecord::RecordNotFound) }
+
+        it { expect(post_transfer_orga1_progress).to json_like({name: 'book-1',
+                                                                organization: 'orga-1',
+                                                                type: 'Book',
+                                                                children: []}) }
+
+        it { expect(post_transfer_orga2_progress).to json_like({name: 'book-1',
+                                                                organization: 'orga-2',
+                                                                type: 'Book',
+                                                                children: [
+                                                                  {
+                                                                    name: 'topic-1',
+                                                                    organization: 'orga-2',
+                                                                    type: 'Topic',
+                                                                    children: [
+                                                                      {
+                                                                        name: 'guide-1',
+                                                                        organization: 'orga-2',
+                                                                        type: 'Guide',
+                                                                        children: [
+                                                                          { name: 'exercise-1', organization: 'orga-2', solution: 'foo', type: 'Assignment' },
+                                                                          { name: 'exercise-2', organization: 'orga-2', solution: 'bar', type: 'Assignment' }
+                                                                        ]}]}]}) }
+      end
+    end
+  end
+end

--- a/spec/models/progress_spec.rb
+++ b/spec/models/progress_spec.rb
@@ -29,6 +29,12 @@ describe Progress do
   let(:exercise2) { create :exercise, name: 'exercise-2' }
   let(:exercise3) { create :exercise, name: 'exercise-3' }
 
+  before do
+    user.make_student_of!(orga1.slug)
+    user.make_student_of!(orga2.slug)
+    user.save!
+  end
+
   # Progress tree for orga1
   #     IB (0/1)
   #     |


### PR DESCRIPTION
I was trying to think of a way to extract the similar logic between the two operations which is pretty easy when thinking of an assignment (defining `copy_to!` as `dup.move_to!`) but it gets pretty intricate and has some undesired consequences when thinking of indicators and their children in particular.

I also realized when console testing this that it's pretty easy to end up with duplicate records, what should we do in those cases @luchotc? 

In terms of strategies, and in order of difficulty, I'm thinking:
~1- Not dealing with it and living with possible duplicates.~
2- Deleting progress for given content on destination and then copying.
3- Merging progress favoring source or destination.
4- All of the above, and letting transferer choose.

Needs tests.

Some thoughts that pop up while pondering about this
- parent of transferred item should be marked dirty in destination?
- actually, not dealing with duplicates [would probably cause problems](https://drive.google.com/file/d/1OpxjYR4eZfgFQPJ2GMBV8igSsTqmEBU_/view?usp=sharing) such as needing to check children are for different contents for an accurate `completion_percentage` and possibly assignments for the same guide not dirtying the same parent.
- how about transferring only orphaned assignments and letting indicator tree build itself?