### PR TITLE
Deliver welcome email now and avoid breaking on errors

### DIFF
--- a/app/models/concerns/with_reminders.rb
+++ b/app/models/concerns/with_reminders.rb
@@ -9,7 +9,7 @@ module WithReminders
   end
 
   def remind!
-    build_reminder.deliver
+    build_reminder.deliver_now
     update! last_reminded_date: Time.now
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -236,7 +236,7 @@ class User < ApplicationRecord
 
   def welcome_to_new_organizations!
     new_accessible_organizations.each do |organization|
-      UserMailer.welcome_email(self, organization).deliver_later if organization.greet_new_users?
+      UserMailer.welcome_email(self, organization).deliver_now rescue nil if organization.greet_new_users?
     end
   end
 


### PR DESCRIPTION
Changing welcome email delivery to use `deliver_now` instead of `deliver_later` since integration tests came up with emails being enqueued to be sent but never actually being popped from the queue afterwards. This behavior seems to only occur when running a nuntius rake task, so once we finish unifying classroom we should change this back to `deliver_later` ideally.

User creation would rollback if template was broken too, so ignoring rendering errors on delivery too.