### PR TITLE
Adding teacher_training flag for organizations

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -190,6 +190,10 @@ class User < ApplicationRecord
     can_discuss_in? Organization.current
   end
 
+  def can_access_teacher_info_in?(organization)
+    teacher_of?(organization) || organization.teacher_training?
+  end
+
   def name_initials
     name.split.map(&:first).map(&:capitalize).join(' ')
   end

--- a/lib/mumuki/domain/incognito.rb
+++ b/lib/mumuki/domain/incognito.rb
@@ -44,6 +44,10 @@ module Mumuki::Domain
       false
     end
 
+    def can_access_teacher_info_in?(*)
+      false
+    end
+
     # ========
     # Visiting
     # ========

--- a/lib/mumuki/domain/organization/settings.rb
+++ b/lib/mumuki/domain/organization/settings.rb
@@ -8,6 +8,7 @@ class Mumuki::Domain::Organization::Settings < Mumukit::Platform::Model
                       :forum_enabled?,
                       :forum_only_for_trusted?,
                       :gamification_enabled?,
+                      :greet_new_users?,
                       :immersive?,
                       :in_preparation_until,
                       :login_methods,
@@ -16,7 +17,7 @@ class Mumuki::Domain::Organization::Settings < Mumukit::Platform::Model
                       :public?,
                       :raise_hand_enabled?,
                       :report_issue_enabled?,
-                      :greet_new_users?
+                      :teacher_training?
 
   def private?
     !public?

--- a/spec/lib/organization_helpers_spec.rb
+++ b/spec/lib/organization_helpers_spec.rb
@@ -22,6 +22,7 @@ describe Mumukit::Platform::Organization do
         forum_enabled: true,
         forum_only_for_trusted: true,
         report_issue_enabled: true,
+        teacher_training: true,
         public: false,
         gamification_enabled: true,
         immersive: false,
@@ -101,6 +102,7 @@ describe Mumukit::Platform::Organization do
         it { expect(subject.immersive?).to eq false }
         it { expect(subject.disabled?).to eq true }
         it { expect(subject.in_preparation?).to eq false }
+        it { expect(subject.teacher_training?).to eq true }
 
         it { expect(Mumuki::Domain::Organization::Settings.parse(nil)).to be_empty }
       end
@@ -135,6 +137,7 @@ describe Mumukit::Platform::Organization do
         it { expect(subject.disabled?).to eq false }
         it { expect(subject.gamification_enabled?).to eq false }
         it { expect(subject.in_preparation?).to eq true }
+        it { expect(subject.teacher_training?).to eq false }
 
         it { expect(Mumuki::Domain::Organization::Settings.load(nil)).to be_empty }
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -347,6 +347,24 @@ describe User, organization_workspace: :test do
     end
   end
 
+  describe '#can_access_teacher_info_in?' do
+    let(:student) { create(:user, permissions: { student: 'test/*' }) }
+    let(:teacher) { create(:user, permissions: { teacher: 'test/*' }) }
+    let(:test_organization) { Organization.locate! 'test' }
+
+    context 'when organization is not a teacher training' do
+      it { expect(student.can_access_teacher_info_in?(test_organization)).to be false }
+      it { expect(teacher.can_access_teacher_info_in?(test_organization)).to be true }
+    end
+
+    context 'when organization is a teacher training everyone can see teacher_info' do
+      before { test_organization.teacher_training = true }
+
+      it { expect(student.can_access_teacher_info_in?(test_organization)).to be true }
+      it { expect(teacher.can_access_teacher_info_in?(test_organization)).to be true }
+    end
+  end
+
   describe '#name_initials' do
     context 'with first_name and last_name' do
       let(:user) { create(:user, first_name: 'John', last_name: 'Doe') }


### PR DESCRIPTION
# Goal :dart: 

This PR adds teacher_training flag for organizations. For now, the only difference is that a in a teacher_training organization students are allowed to see the teacher_info as well.
