### PR TITLE
Fix dead indicator tree branches

### DIFF
--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -57,6 +57,10 @@ class Indicator < Progress
     children_passed_count == children_count
   end
 
+  def self.delete_all_for!(content, organization)
+    where(content: content, organization: organization).delete_all
+  end
+
   private
 
   def children

--- a/app/models/usage.rb
+++ b/app/models/usage.rb
@@ -8,6 +8,7 @@ class Usage < ApplicationRecord
 
   before_save :set_slug
   before_destroy :destroy_children_usages!
+  before_destroy :delete_associated_indicators!
 
   def self.destroy_all_where(query)
     where(query).destroy_all
@@ -26,6 +27,10 @@ class Usage < ApplicationRecord
   end
 
   private
+
+  def delete_associated_indicators!
+    Indicator.delete_all_for!(item, organization)
+  end
 
   def set_slug
     self.slug = item.slug

--- a/spec/models/indicator_spec.rb
+++ b/spec/models/indicator_spec.rb
@@ -97,5 +97,13 @@ describe Indicator, organization_workspace: :test do
         it { expect(book_indicator).to_not be_dirty_by_submission }
       end
     end
+
+    context 'past children should not affect new progress tree' do
+      before { topic_indicator.send :children_count }
+      before { topic.import_from_resource_h!(topic.to_resource_h.merge lessons: []) }
+
+      it { expect(topic_indicator.reload.send :children_count).to eq 0 }
+      it { expect(topic_indicator.reload.send :children_passed_count).to eq 0 }
+    end
   end
 end


### PR DESCRIPTION
These tests prove the behavior we were talking about the other day @luchotc.

As for a fix, I'm thinking we could just add a `before_destroy` to `Usage` and either delete, or unlink associated the corresponding indicators. Any preference regarding that? 

Deleting is the better option if the content is never readded to the organization, since we'd be keeping less useless records (although we don't delete assignments).
If we expect the content to be readded to the organization later then unlinking would be better as the relinking process would be less resource intensive (we'd only have to relink indicators instead of assignments, which are fewer in numbers).