### PR TITLE
Feature add audit fields to discussion status changes

### DIFF
--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -4,7 +4,10 @@ class Discussion < ApplicationRecord
   belongs_to :item, polymorphic: true
   has_many :messages, -> { order(:created_at) }, dependent: :destroy
   belongs_to :initiator, class_name: 'User'
+
   belongs_to :last_moderator_access_by, class_name: 'User', optional: true
+  belongs_to :status_updated_by, class_name: 'User', optional: true
+
   belongs_to :exercise, foreign_type: :exercise, foreign_key: 'item_id'
   belongs_to :organization
   has_many :subscriptions
@@ -106,7 +109,11 @@ class Discussion < ApplicationRecord
   end
 
   def update_status!(status, user)
-    update!(status: status) if reachable_status_for?(user, status)
+    if reachable_status_for?(user, status)
+      update! status: status,
+              status_updated_by: user,
+              status_updated_at: Time.now
+    end
   end
 
   def has_messages?

--- a/db/migrate/20201009193949_add_status_updated_fields_to_discussion.rb
+++ b/db/migrate/20201009193949_add_status_updated_fields_to_discussion.rb
@@ -1,0 +1,6 @@
+class AddStatusUpdatedFieldsToDiscussion < ActiveRecord::Migration[5.1]
+  def change
+    add_column :discussions, :status_updated_by_id, :string
+    add_column :discussions, :status_updated_at, :datetime
+  end
+end

--- a/db/migrate/20201009193949_add_status_updated_fields_to_discussion.rb
+++ b/db/migrate/20201009193949_add_status_updated_fields_to_discussion.rb
@@ -1,6 +1,6 @@
 class AddStatusUpdatedFieldsToDiscussion < ActiveRecord::Migration[5.1]
   def change
-    add_column :discussions, :status_updated_by_id, :string
+    add_reference :discussions, :status_updated_by, index: true
     add_column :discussions, :status_updated_at, :datetime
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200804191643) do
+ActiveRecord::Schema.define(version: 20201009193949) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,8 @@ ActiveRecord::Schema.define(version: 20200804191643) do
     t.boolean "requires_moderator_response", default: true
     t.string "last_moderator_access_by_id"
     t.datetime "last_moderator_access_at"
+    t.string "status_updated_by_id"
+    t.datetime "status_updated_at"
     t.index ["initiator_id"], name: "index_discussions_on_initiator_id"
     t.index ["item_type", "item_id"], name: "index_discussions_on_item_type_and_item_id"
     t.index ["organization_id"], name: "index_discussions_on_organization_id"
@@ -311,8 +313,8 @@ ActiveRecord::Schema.define(version: 20200804191643) do
     t.text "theme", default: "{}", null: false
     t.text "profile", default: "{}", null: false
     t.integer "progressive_display_lookahead"
-    t.integer "target_audience", default: 0
     t.boolean "incognito_mode_enabled"
+    t.integer "target_audience", default: 0
     t.index ["book_id"], name: "index_organizations_on_book_id"
     t.index ["name"], name: "index_organizations_on_name", unique: true
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -124,11 +124,12 @@ ActiveRecord::Schema.define(version: 20201009193949) do
     t.boolean "requires_moderator_response", default: true
     t.string "last_moderator_access_by_id"
     t.datetime "last_moderator_access_at"
-    t.string "status_updated_by_id"
+    t.bigint "status_updated_by_id"
     t.datetime "status_updated_at"
     t.index ["initiator_id"], name: "index_discussions_on_initiator_id"
     t.index ["item_type", "item_id"], name: "index_discussions_on_item_type_and_item_id"
     t.index ["organization_id"], name: "index_discussions_on_organization_id"
+    t.index ["status_updated_by_id"], name: "index_discussions_on_status_updated_by_id"
   end
 
   create_table "exam_authorizations", force: :cascade do |t|

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -89,6 +89,7 @@ describe Discussion, organization_workspace: :test do
         before { discussion.update_status!(:solved, moderator) }
 
         it { expect(discussion.status).to eq :solved }
+        it { expect(discussion.reachable_statuses_for initiator).to eq [] }
         it { expect(discussion.status_updated_by).to eq moderator }
         it { expect(discussion.status_updated_at).to be < Time.now }
         it { expect(discussion.reachable_statuses_for moderator).to eq [:opened, :closed] }

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -41,6 +41,8 @@ describe Discussion, organization_workspace: :test do
         before { discussion.update_status!(:closed, initiator) }
 
         it { expect(discussion.status).to eq :closed }
+        it { expect(discussion.status_updated_by).to eq initiator }
+        it { expect(discussion.status_updated_at).to be < Time.now }
         it { expect(discussion.reachable_statuses_for initiator).to eq [] }
         it { expect(discussion.reachable_statuses_for moderator).to eq [:opened, :solved] }
         it { expect(discussion.reachable_statuses_for student).to eq [] }
@@ -87,7 +89,8 @@ describe Discussion, organization_workspace: :test do
         before { discussion.update_status!(:solved, moderator) }
 
         it { expect(discussion.status).to eq :solved }
-        it { expect(discussion.reachable_statuses_for initiator).to eq [] }
+        it { expect(discussion.status_updated_by).to eq moderator }
+        it { expect(discussion.status_updated_at).to be < Time.now }
         it { expect(discussion.reachable_statuses_for moderator).to eq [:opened, :closed] }
         it { expect(discussion.reachable_statuses_for student).to eq [] }
         it { expect(discussion.commentable_by? student).to be false }


### PR DESCRIPTION
# :dart: Goal 

In a lot of contexts @NadiaFinzi @Gustrucco and @rgonzalezt have pointed out that it would be nice to track not only when a moderator posts a message, but also when a moderator solves or closes a discussion. This PR adds audit fields to status changes,. 

# :beetle: Potential bugs found

I have noticed that there are already similar audit fields for last_access, but FK to user is stored as a string ( :exclamation: ) and without and index (:thinking:): 

```ruby
add_column :discussions, :last_moderator_access_by_id, :string
add_column :discussions, :last_moderator_access_at, :datetime
```
 
I am not sure if that was done as intended or not, but I think it is weird. I am not changing this as part of this PR, though. 

# :mag: Notes for reviewer 

I have little experience with the discussion model, so a highly critical review would be appreciated. 

# :back: Backward compatibility

This is new feature, but it is backwards compatible. Not changes in client code - aside of migrations - are required. 

