### PR TITLE
Feature submit to main organization

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -182,7 +182,7 @@ class Assignment < Progress
                 exercise: {only: [:name, :number]},
                 submitter: {only: [:email, :social_id, :uid], methods: [:name, :profile_picture]}}).
       deep_merge(
-        'organization' => submitter.recommended_organic_context_at(guide).name,
+        'organization' => submitter.recommended_organic_context_at(exercise).name,
         'sid' => submission_id,
         'created_at' => submitted_at || updated_at,
         'content' => solution,

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -94,12 +94,12 @@ class Assignment < Progress
     unless Organization.silenced?
       contexts = current_notification_contexts
       update_missplaced!(contexts.size > 1)
-      contexts.uniq.each { |it| Mumukit::Nuntius.notify! 'submissions', to_resource_h(context: it) }
+      contexts.each { |it| Mumukit::Nuntius.notify! 'submissions', to_resource_h(context: it) }
     end
   end
 
   def current_notification_contexts
-    [Organization.current, submitter.current_immersive_context_at(exercise)]
+    [Organization.current, submitter.current_immersive_context_at(exercise)].uniq
   end
 
   def notify_to_accessible_organizations!

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -247,6 +247,10 @@ class Assignment < Progress
     self.top_submission_status = submission_status unless submission_status.improved_by?(top_submission_status)
   end
 
+  def update_misplaced!(value)
+    update! misplaced: value if value != misplaced?
+  end
+
   private
 
   def update_submissions_count!
@@ -263,10 +267,6 @@ class Assignment < Progress
 
   def update_last_submission!
     submitter.update!(last_submission_date: DateTime.current, last_exercise: exercise)
-  end
-
-  def update_misplaced!(value)
-    update! misplaced: value if value != misplaced?
   end
 
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -92,13 +92,13 @@ class Assignment < Progress
 
   def notify!
     unless Organization.silenced?
-      contexts = notification_contexts
+      contexts = current_notification_contexts
       update_missplaced!(contexts.size > 1)
       contexts.uniq.each { |it| Mumukit::Nuntius.notify! 'submissions', to_resource_h(context: it) }
     end
   end
 
-  def notification_contexts
+  def current_notification_contexts
     [Organization.current, submitter.current_immersive_context_at(exercise)]
   end
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -182,7 +182,7 @@ class Assignment < Progress
                 exercise: {only: [:name, :number]},
                 submitter: {only: [:email, :social_id, :uid], methods: [:name, :profile_picture]}}).
       deep_merge(
-        'organization' => contextual_organization.name,
+        'organization' => user.immersive_main_organic_context.name,
         'sid' => submission_id,
         'created_at' => submitted_at || updated_at,
         'content' => solution,
@@ -196,10 +196,6 @@ class Assignment < Progress
           'position' => navigable_parent.try(:number),
           'chapter' => guide.chapter.as_json(only: [:id], methods: [:name])
         }})
-  end
-
-  def contextual_organization
-    user.immersive_main_organization || Organization.current
   end
 
   def tips

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -199,11 +199,7 @@ class Assignment < Progress
   end
 
   def contextual_organization
-    if user.has_immersive_main_organization?
-      user.main_organization
-    else
-      Organization.current
-    end
+    user.immersive_main_organization || Organization.current
   end
 
   def tips

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -182,7 +182,7 @@ class Assignment < Progress
                 exercise: {only: [:name, :number]},
                 submitter: {only: [:email, :social_id, :uid], methods: [:name, :profile_picture]}}).
       deep_merge(
-        'organization' => Organization.current.name,
+        'organization' => contextual_organization,
         'sid' => submission_id,
         'created_at' => submitted_at || updated_at,
         'content' => solution,
@@ -196,6 +196,14 @@ class Assignment < Progress
           'position' => navigable_parent.try(:number),
           'chapter' => guide.chapter.as_json(only: [:id], methods: [:name])
         }})
+  end
+
+  def contextual_organization
+    if user.has_immersive_main_organization?
+      user.main_organization
+    else
+      Organization.current.name
+    end
   end
 
   def tips

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -92,7 +92,9 @@ class Assignment < Progress
 
   def notify!
     unless Organization.silenced?
-      notification_contexts.uniq.each { |it| Mumukit::Nuntius.notify! 'submissions', to_resource_h(context: it) }
+      contexts = notification_contexts
+      update_missplaced!(notification_contexts.size > 1)
+      contexts.uniq.each { |it| Mumukit::Nuntius.notify! 'submissions', to_resource_h(context: it) }
     end
   end
 
@@ -176,7 +178,7 @@ class Assignment < Progress
   def to_resource_h(options = {})
     context = options[:context] || Organization.current
     excluded_fields = %i(created_at exercise_id id organization_id parent_id solution submission_id
-                         submission_status submitted_at submitter_id top_submission_status updated_at)
+                         submission_status submitted_at submitter_id top_submission_status updated_at missplaced)
 
     as_json(except: excluded_fields,
               include: {
@@ -261,6 +263,10 @@ class Assignment < Progress
 
   def update_last_submission!
     submitter.update!(last_submission_date: DateTime.current, last_exercise: exercise)
+  end
+
+  def update_missplaced!(value)
+    update! missplaced: value if value != missplaced?
   end
 
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -93,7 +93,7 @@ class Assignment < Progress
   def notify!
     unless Organization.silenced?
       contexts = notification_contexts
-      update_missplaced!(notification_contexts.size > 1)
+      update_missplaced!(contexts.size > 1)
       contexts.uniq.each { |it| Mumukit::Nuntius.notify! 'submissions', to_resource_h(context: it) }
     end
   end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -182,7 +182,7 @@ class Assignment < Progress
                 exercise: {only: [:name, :number]},
                 submitter: {only: [:email, :social_id, :uid], methods: [:name, :profile_picture]}}).
       deep_merge(
-        'organization' => contextual_organization,
+        'organization' => contextual_organization.name,
         'sid' => submission_id,
         'created_at' => submitted_at || updated_at,
         'content' => solution,
@@ -202,7 +202,7 @@ class Assignment < Progress
     if user.has_immersive_main_organization?
       user.main_organization
     else
-      Organization.current.name
+      Organization.current
     end
   end
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -182,7 +182,7 @@ class Assignment < Progress
                 exercise: {only: [:name, :number]},
                 submitter: {only: [:email, :social_id, :uid], methods: [:name, :profile_picture]}}).
       deep_merge(
-        'organization' => user.immersive_main_organic_context.name,
+        'organization' => submitter.recommended_organic_context_at(guide).name,
         'sid' => submission_id,
         'created_at' => submitted_at || updated_at,
         'content' => solution,

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -182,7 +182,7 @@ class Assignment < Progress
                 exercise: {only: [:name, :number]},
                 submitter: {only: [:email, :social_id, :uid], methods: [:name, :profile_picture]}}).
       deep_merge(
-        'organization' => submitter.recommended_organic_context_at(exercise).name,
+        'organization' => submitter.current_immersive_context_at(exercise).name,
         'sid' => submission_id,
         'created_at' => submitted_at || updated_at,
         'content' => solution,

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -93,7 +93,7 @@ class Assignment < Progress
   def notify!
     unless Organization.silenced?
       contexts = current_notification_contexts
-      update_missplaced!(contexts.size > 1)
+      update_misplaced!(contexts.size > 1)
       contexts.each { |it| Mumukit::Nuntius.notify! 'submissions', to_resource_h(context: it) }
     end
   end
@@ -178,7 +178,7 @@ class Assignment < Progress
   def to_resource_h(options = {})
     context = options[:context] || Organization.current
     excluded_fields = %i(created_at exercise_id id organization_id parent_id solution submission_id
-                         submission_status submitted_at submitter_id top_submission_status updated_at missplaced)
+                         submission_status submitted_at submitter_id top_submission_status updated_at misplaced)
 
     as_json(except: excluded_fields,
               include: {
@@ -265,8 +265,8 @@ class Assignment < Progress
     submitter.update!(last_submission_date: DateTime.current, last_exercise: exercise)
   end
 
-  def update_missplaced!(value)
-    update! missplaced: value if value != missplaced?
+  def update_misplaced!(value)
+    update! misplaced: value if value != misplaced?
   end
 
 end

--- a/app/models/concerns/contextualization.rb
+++ b/app/models/concerns/contextualization.rb
@@ -51,7 +51,7 @@ module Contextualization
   end
 
   def single_visible_test_result?
-    test_results.size == 1 && visible_success_output?
+    test_results.single? && visible_success_output?
   end
 
   def first_test_result

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -240,10 +240,9 @@ class User < ApplicationRecord
     Organization.current? ?  Organization.current : main_organization
   end
 
-  def recommended_organic_context_at(exercise)
+  def current_immersive_context_at(exercise)
     if Organization.current?
-      replacement = recommended_replacement_organization
-      exercise&.used_in?(replacement) ? replacement : Organization.current
+      immersive_organization_at(exercise) || Organization.current
     else
       main_organization
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -236,6 +236,19 @@ class User < ApplicationRecord
     end
   end
 
+  def current_organic_context
+    Organization.current? ?  Organization.current : main_organization
+  end
+
+  def recommended_organic_context_at(content)
+    if Organization.current?
+      replacement = recommended_replacement_organization
+      content&.used_in?(replacement) ? replacement : Organization.current
+    else
+      main_organization
+    end
+  end
+
   private
 
   def welcome_to_new_organizations!
@@ -288,13 +301,5 @@ class User < ApplicationRecord
 
   def self.buried_profile
     (@buried_profile || {}).slice(:first_name, :last_name, :email)
-  end
-
-  def current_organic_context
-    Organization.current? ?  Organization.current : main_organization
-  end
-
-  def immersive_main_organic_context
-    user.immersive_main_organization || Organization.current
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -240,10 +240,10 @@ class User < ApplicationRecord
     Organization.current? ?  Organization.current : main_organization
   end
 
-  def recommended_organic_context_at(content)
+  def recommended_organic_context_at(exercise)
     if Organization.current?
       replacement = recommended_replacement_organization
-      content&.used_in?(replacement) ? replacement : Organization.current
+      exercise&.used_in?(replacement) ? replacement : Organization.current
     else
       main_organization
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -291,10 +291,10 @@ class User < ApplicationRecord
   end
 
   def current_organic_context
-    if Organization.current?
-      Organization.current
-    else
-      main_organization
-    end
+    Organization.current? ?  Organization.current : main_organization
+  end
+
+  def immersive_main_organic_context
+    user.immersive_main_organization || Organization.current
   end
 end

--- a/db/migrate/20201019191036_add_misplaced_flag_to_submission.rb
+++ b/db/migrate/20201019191036_add_misplaced_flag_to_submission.rb
@@ -1,0 +1,5 @@
+class AddMisplacedFlagToSubmission < ActiveRecord::Migration[5.1]
+  def change
+    add_column :assignments, :misplaced, :boolean
+  end
+end

--- a/db/migrate/20201019191036_add_missplaced_flag_to_submission.rb
+++ b/db/migrate/20201019191036_add_missplaced_flag_to_submission.rb
@@ -1,5 +1,0 @@
-class AddMissplacedFlagToSubmission < ActiveRecord::Migration[5.1]
-  def change
-    add_column :assignments, :missplaced, :boolean
-  end
-end

--- a/db/migrate/20201019191036_add_missplaced_flag_to_submission.rb
+++ b/db/migrate/20201019191036_add_missplaced_flag_to_submission.rb
@@ -1,0 +1,5 @@
+class AddMissplacedFlagToSubmission < ActiveRecord::Migration[5.1]
+  def change
+    add_column :assignments, :missplaced, :boolean
+  end
+end

--- a/lib/mumuki/domain/extensions/array.rb
+++ b/lib/mumuki/domain/extensions/array.rb
@@ -2,6 +2,19 @@ class Array
   def insert_last(element)
     self + [element]
   end
+
+  def single
+    first if single?
+  end
+
+  def single!
+    raise 'There is more than one element' unless single?
+    first
+  end
+
+  def single?
+    size == 1
+  end
 end
 
 class NilClass

--- a/lib/mumuki/domain/helpers/organization.rb
+++ b/lib/mumuki/domain/helpers/organization.rb
@@ -28,8 +28,12 @@ module Mumuki::Domain::Helpers::Organization
     name == 'base'
   end
 
-  def replaced_by?(other)
-    public? && other.immersive? && target_audience == other.target_audience
+  def immersible?
+    public?
+  end
+
+  def immersed_in?(other)
+    immersible? && other.immersive? && target_audience == other.target_audience
   end
 
   def switch!

--- a/lib/mumuki/domain/helpers/organization.rb
+++ b/lib/mumuki/domain/helpers/organization.rb
@@ -28,6 +28,10 @@ module Mumuki::Domain::Helpers::Organization
     name == 'base'
   end
 
+  def replaced_by?(other)
+    public? && other.immersive? && target_audience == other.target_audience
+  end
+
   def switch!
     Mumukit::Platform::Organization.switch! self
   end

--- a/lib/mumuki/domain/helpers/user.rb
+++ b/lib/mumuki/domain/helpers/user.rb
@@ -95,6 +95,15 @@ module Mumuki::Domain::Helpers::User
     main_organization.try { |it| it if it.immersive? }
   end
 
+  def recommended_organization
+    recommendations = student_granted_organizations.select { |it| it.immersive? }
+    recommendations.first if recommendations.size == 1
+  end
+
+  def recommended_replacement_organization(other = Organization.current)
+    recommended_organization.try { |it| it if other.replaced_by?(it) }
+  end
+
   ## API Exposure
 
   def to_param

--- a/lib/mumuki/domain/helpers/user.rb
+++ b/lib/mumuki/domain/helpers/user.rb
@@ -97,7 +97,7 @@ module Mumuki::Domain::Helpers::User
   def immersive_organization_at(path_item, current = Organization.current)
     return nil unless current.immersible?
 
-    usage_filter = path_item ? lambda { |it| path_item.used_in?(it) } : lambda { true }
+    usage_filter = path_item ? lambda { |it| path_item.used_in?(it) } : lambda { |_| true }
     student_granted_organizations
       .select { |it| current.immersed_in?(it) }
       .select(&usage_filter)

--- a/lib/mumuki/domain/helpers/user.rb
+++ b/lib/mumuki/domain/helpers/user.rb
@@ -88,7 +88,11 @@ module Mumuki::Domain::Helpers::User
   end
 
   def has_immersive_main_organization?
-    !!main_organization.try(&:immersive?)
+    immersive_main_organization.present?
+  end
+
+  def immersive_main_organization
+    main_organization.try { |it| it if it.immersive? }
   end
 
   ## API Exposure

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 20201019191036) do
     t.datetime "submitted_at"
     t.bigint "parent_id"
     t.integer "top_submission_status"
-    t.boolean "missplaced"
+    t.boolean "misplaced"
     t.index ["exercise_id"], name: "index_assignments_on_exercise_id"
     t.index ["organization_id"], name: "index_assignments_on_organization_id"
     t.index ["parent_id"], name: "index_assignments_on_parent_id"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201009193949) do
+ActiveRecord::Schema.define(version: 20201019191036) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 20201009193949) do
     t.datetime "submitted_at"
     t.bigint "parent_id"
     t.integer "top_submission_status"
+    t.boolean "missplaced"
     t.index ["exercise_id"], name: "index_assignments_on_exercise_id"
     t.index ["organization_id"], name: "index_assignments_on_organization_id"
     t.index ["parent_id"], name: "index_assignments_on_parent_id"

--- a/spec/lib/user_helpers_spec.rb
+++ b/spec/lib/user_helpers_spec.rb
@@ -148,7 +148,6 @@ describe Mumuki::Domain::Helpers::User do
       it { expect(user.student_granted_organizations).to eq [] }
       it { expect(user.has_student_granted_organizations?).to be false }
       it { expect(user.has_immersive_main_organization?).to be false }
-      it { expect(user.immersive_main_organization).to be nil }
     end
 
     context 'with organization' do
@@ -158,11 +157,9 @@ describe Mumuki::Domain::Helpers::User do
       it { expect(user.student_granted_organizations).to eq [organization] }
       it { expect(user.has_student_granted_organizations?).to be true }
       it { expect(user.has_immersive_main_organization?).to be false }
-      it { expect(user.immersive_main_organization).to be nil }
 
       context 'when immersive' do
         before { organization.settings.immersive = true }
-        it { expect(user.immersive_main_organization).to eq organization }
       end
     end
   end

--- a/spec/lib/user_helpers_spec.rb
+++ b/spec/lib/user_helpers_spec.rb
@@ -148,6 +148,7 @@ describe Mumuki::Domain::Helpers::User do
       it { expect(user.student_granted_organizations).to eq [] }
       it { expect(user.has_student_granted_organizations?).to be false }
       it { expect(user.has_immersive_main_organization?).to be false }
+      it { expect(user.immersive_main_organization).to be nil }
     end
 
     context 'with organization' do
@@ -157,10 +158,11 @@ describe Mumuki::Domain::Helpers::User do
       it { expect(user.student_granted_organizations).to eq [organization] }
       it { expect(user.has_student_granted_organizations?).to be true }
       it { expect(user.has_immersive_main_organization?).to be false }
+      it { expect(user.immersive_main_organization).to be nil }
 
       context 'when immersive' do
         before { organization.settings.immersive = true }
-        it { expect(user.has_immersive_main_organization?).to be true }
+        it { expect(user.immersive_main_organization).to eq organization }
       end
     end
   end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -192,6 +192,48 @@ describe Assignment, organization_workspace: :test do
     it { expect(exercise.assignments.first.organization).to eq Organization.current }
   end
 
+  describe 'update_misplaced!' do
+    let(:exercise) { create(:exercise) }
+    let(:user) { create(:user) }
+    let(:assignment) { Assignment.create(exercise: exercise, submitter: user, misplaced: misplaced) }
+
+    context 'when nil' do
+      let(:misplaced) { nil }
+      context 'then false' do
+        before { assignment.update_misplaced! false }
+        it { expect(assignment.misplaced).to be nil }
+      end
+      context 'then true' do
+        before { assignment.update_misplaced! true }
+        it { expect(assignment.misplaced).to be true }
+      end
+    end
+
+    context 'when true' do
+      let(:misplaced) { true }
+      context 'then false' do
+        before { assignment.update_misplaced! false }
+        it { expect(assignment.misplaced).to be false }
+      end
+      context 'then true' do
+        before { assignment.update_misplaced! true }
+        it { expect(assignment.misplaced).to be true }
+      end
+    end
+
+    context 'when false' do
+      let(:misplaced) { false }
+      context 'then false' do
+        before { assignment.update_misplaced! false }
+        it { expect(assignment.misplaced).to be false }
+      end
+      context 'then true' do
+        before { assignment.update_misplaced! true }
+        it { expect(assignment.misplaced).to be true }
+      end
+    end
+  end
+
   describe 'organization' do
     let(:exercise) { create(:exercise) }
     let(:user) { create(:user) }

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -262,4 +262,22 @@ describe Organization, organization_workspace: :test do
       it { expect(organization.display_name).to be_nil }
     end
   end
+
+  describe '#immersible?' do
+    context 'current public' do
+      let(:one) { build(:organization, public: true) }
+
+      let(:other_immersive) { build(:organization, immersive: true) }
+      let(:other_non_immersive) { build(:organization, immersive: true) }
+
+      it { expect(one.immersible?).to be true }
+      it { expect(one.immersed_in? other_immersive).to be true }
+      it { expect(one.immersed_in? other_non_immersive).to be true }
+    end
+
+    context 'current private' do
+      let(:one) { build(:organization, public: false) }
+      it { expect(one.immersible?).to be false }
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -146,6 +146,31 @@ describe User, organization_workspace: :test do
     end
   end
 
+
+  describe '#recommended_replacement_organization' do
+    let(:student) { create :user }
+
+    context 'when no granted organizations' do
+      it { expect(student.recommended_replacement_organization).to eq Organization.current }
+    end
+
+    context 'when granted organizations' do
+      let(:other_organization) { create :organization, immersive: immersive }
+
+      before { student.add_permission! :teacher, other_organization }
+
+      context 'when granted organizations but not immersive' do
+        let(:immersive) { false }
+        it { expect(student.recommended_replacement_organization).to eq Organization.current }
+      end
+
+      context 'when granted organizations and not immersive' do
+        let(:immersive) { true }
+        it { expect(student.recommended_replacement_organization).to eq student.recommended_organization }
+      end
+    end
+  end
+
   describe '#completed_containers_with_lookahead' do
     let(:student) { create :user }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -147,11 +147,11 @@ describe User, organization_workspace: :test do
   end
 
 
-  describe '#recommended_replacement_organization' do
+  describe '#immersive_organization_at' do
     let(:student) { create :user }
 
     context 'when no granted organizations' do
-      it { expect(student.recommended_replacement_organization).to eq Organization.current }
+      it { expect(student.immersive_organization_at nil).to eq Organization.current }
     end
 
     context 'when granted organizations' do
@@ -161,12 +161,12 @@ describe User, organization_workspace: :test do
 
       context 'when granted organizations but not immersive' do
         let(:immersive) { false }
-        it { expect(student.recommended_replacement_organization).to eq Organization.current }
+        it { expect(student.immersive_organization_at nil).to eq Organization.current }
       end
 
       context 'when granted organizations and not immersive' do
         let(:immersive) { true }
-        it { expect(student.recommended_replacement_organization).to eq student.recommended_organization }
+        it { expect(student.immersive_organization_at nil).to eq other_organization }
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -147,7 +147,7 @@ describe User, organization_workspace: :test do
   end
 
 
-  describe '#immersive_organization_at' do
+  describe 'immeresive behaviour' do
     let(:student) { create :user }
 
     context 'when no granted organizations' do
@@ -177,6 +177,7 @@ describe User, organization_workspace: :test do
           context 'when content is tested' do
             let(:exercise) { create(:exercise) }
             let!(:chapter) { create(:chapter, lessons: [ create(:lesson, exercises: [exercise] )]) }
+            let(:assignment) { Assignment.new exercise: exercise, submitter: student }
 
             before { reindex_current_organization! }
 
@@ -187,10 +188,12 @@ describe User, organization_workspace: :test do
               end
 
               it { expect(student.immersive_organization_at exercise).to eq other_organization }
+              it { expect(assignment.current_notification_contexts).to eq [Organization.current, other_organization] }
             end
 
             context 'when content is not shared' do
               it { expect(student.immersive_organization_at exercise).to be nil }
+              it { expect(assignment.current_notification_contexts).to eq [Organization.current] }
             end
           end
         end


### PR DESCRIPTION
# :dart: Goal

To avoid the need of most resubmissions by sending to the main immersive organization if present

# :memo: Details

This PR introduces the concept of `immersive_organization_at` which is the place where user is _supposed_ to be in _most_ cases. This organization is determined using explicit permissions, content sharing, target audience, publicity and immersivity. 

This PR also extends the concept of `current_organic_context` to `current_immersive_context`, which supersedes it by  taking immersivity into account. 


Using those concepts, the following notification-specific actions are taken: 

1. Assignments that belong to more than a single context are notified to all of them
2. Such assignments are also marked as _missplaced_ reflecting that they are possible in the wrong context
 

# :soon: Future work

This PR assumes that in the future the UI may actually redirect user to such organic contexts. In that scenario, notifying to all of them will be useless since that scenario may not happen anymore. However the building blocks of `current_immersive_context_at` and `immersive_organization_at` will be still meaningful. 

# :thinking: Doubts

I am still considering that a user's current organization is immersed into another when she has explicit **student** permissions. This is an old design decision, but perhaps we could extend it to teachers, too.

I am not notifying the new `misplaced` flag, but perhaps it may be a good idea to do so. 

# :ballot_box_with_check: Pending work

I should test the misplaced flag, too.  
