### PR TITLE
Convert invalid lookahead values into nil

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -135,7 +135,7 @@ class Organization < ApplicationRecord
   end
 
   def progressive_display_lookahead=(lookahead)
-    self[:progressive_display_lookahead] = lookahead && lookahead > 0 ? lookahead : nil
+    self[:progressive_display_lookahead] = lookahead&.positive? ? lookahead : nil
   end
 
   private

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -134,6 +134,10 @@ class Organization < ApplicationRecord
     name.try { |it| it.gsub(/\W/, ' ').titleize }
   end
 
+  def progressive_display_lookahead=(lookahead)
+    self[:progressive_display_lookahead] = lookahead && lookahead > 0 ? lookahead : nil
+  end
+
   private
 
   def ensure_consistent_public_login

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -280,4 +280,42 @@ describe Organization, organization_workspace: :test do
       it { expect(one.immersible?).to be false }
     end
   end
+
+  describe 'lookahead' do
+    let(:organization) { build(:organization, name: 'foo') }
+
+    describe '#enable_progressive_display!' do
+      context 'invalid lookahead' do
+        before { organization.enable_progressive_display! lookahead: 0 }
+        it { expect(organization.progressive_display_lookahead).to be nil }
+      end
+
+      context 'positive lookahead' do
+        before { organization.enable_progressive_display! }
+        it { expect(organization.progressive_display_lookahead).to eq 1 }
+      end
+    end
+
+    describe '#progressive_display=' do
+      context 'nil lookahead' do
+        before { organization.progressive_display_lookahead = nil }
+        it { expect(organization.progressive_display_lookahead).to be nil }
+      end
+
+      context 'zero lookahead' do
+        before { organization.progressive_display_lookahead = 0 }
+        it { expect(organization.progressive_display_lookahead).to be nil }
+      end
+
+      context 'positive lookahead' do
+        before { organization.progressive_display_lookahead = 2 }
+        it { expect(organization.progressive_display_lookahead).to eq 2 }
+      end
+
+      context 'negative lookahead' do
+        before { organization.progressive_display_lookahead = -1 }
+        it { expect(organization.progressive_display_lookahead).to be nil }
+      end
+    end
+  end
 end


### PR DESCRIPTION
# :dart: Goal

Avoid having invalid values in organization's `progressive_display_lookahead`

# :memo: Details

`progressive_display_lookahead` must be nil or positive, but not negative or zero. This PR just silently corrects invalid values. I could have just validated that condition and raise an error, but I think this behavior is more  API-friendly and still non-surprising. 

