### PR TITLE
Do not sanitize affable test results

### DIFF
--- a/app/models/concerns/contextualization.rb
+++ b/app/models/concerns/contextualization.rb
@@ -135,4 +135,8 @@ module Contextualization
           status: it[:status])
     end
   end
+
+  def sanitized_affable_test_results
+    affable_test_results.each { |it| it[:result] = it[:result]&.sanitized }
+  end
 end

--- a/app/models/concerns/contextualization.rb
+++ b/app/models/concerns/contextualization.rb
@@ -131,7 +131,7 @@ module Contextualization
         .compact
         .merge(
           title: it[:title].affable,
-          result: it[:result].sanitized,
+          result: it[:result],
           status: it[:status])
     end
   end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -364,6 +364,32 @@ describe Assignment, organization_workspace: :test do
       it { expect(assignment.affable_test_results).to eq [{status: :failed, title: '<em>first</em> test', result: 'result'},
                                                           {status: :failed, title: 'second test', result: 'result', summary: 'you are using a function <strong>you have not declared</strong>'} ]  }
     end
+
+    context 'it does not sanitize test results' do
+      before { Mumukit::ContentType::Sanitizer.should_sanitize = true }
+      after { Mumukit::ContentType::Sanitizer.should_sanitize = false }
+
+      let(:test_results) do
+        [ {status: :failed, title: 'title', result: 'Expected <10>'} ]
+      end
+
+      it { expect(assignment.affable_test_results).to eq [{status: :failed, title: 'title', result: 'Expected <10>'}]  }
+    end
+  end
+
+  describe '#sanitized_affable_test_results' do
+    let(:assignment) { create(:assignment, test_results: test_results) }
+
+    context 'it escapes test results' do
+      before { Mumukit::ContentType::Sanitizer.should_sanitize = true }
+      after { Mumukit::ContentType::Sanitizer.should_sanitize = false }
+
+      let(:test_results) do
+        [ { status: :failed, title: 'title', result: 'Expected <10>' } ]
+      end
+
+      it { expect(assignment.sanitized_affable_test_results).to eq [{status: :failed, title: 'title', result: 'Expected &lt;10&gt;'} ]  }
+    end
   end
 
   describe '#update_top_submission!' do


### PR DESCRIPTION
Fixes some result display problems where something like:
```
Expected: <49> but got <50>
```

would show up as:
```
Expected: &lt;49&gt; but got &lt;50&gt;
```

The problem is not really in the sanitization itself, but on the results rendering flow:
1- We sanitize results, turning ` ```<49>``` ` into ` ```&lt;49&gt;``` ` (not as a result of sanitization but rather as a result of parsing as html fragment and converting back to string).
2- We then convert markdown to html which results in `<code>&lt;49&gt;</code>`.

The problem with that is that the content within the `code` tags is not displayed as html, so the `&lt;` and `&gt;` are not rendered as `<` and `>`.

Removing step 1 fixes the visual issue, and with the current it has does not introduce a security issue as we're then processing results with `test_result_html`, which sanitizes the resulting html.

We _should_ however be aware that this means affable_test_results can include malicious code which should be sanitized at the appropiate time. 