### PR TITLE
Chore: add immersible flag to organization

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -16,6 +16,7 @@ class Organization < ApplicationRecord
 
   validate :ensure_consistent_public_login
   validate :ensure_valid_activity_range
+  validate :ensure_not_immersive_and_immersible
 
   belongs_to :book
   has_many :usages
@@ -167,6 +168,10 @@ class Organization < ApplicationRecord
   end
 
   private
+
+  def ensure_not_immersive_and_immersible
+    errors.add(:immersible, :cannot_be_immersive) if immersible? && immersive?
+  end
 
   def ensure_consistent_public_login
     errors.add(:base, :consistent_public_login) if settings.customized_login_methods? && public?

--- a/db/migrate/20201027134205_add_immersible_to_organization.rb
+++ b/db/migrate/20201027134205_add_immersible_to_organization.rb
@@ -1,5 +1,5 @@
 class AddImmersibleToOrganization < ActiveRecord::Migration[5.1]
   def change
-    add_column :organizations, :immersible, :boolean, default: false
+    add_column :organizations, :immersible, :boolean
   end
 end

--- a/db/migrate/20201027134205_add_immersible_to_organization.rb
+++ b/db/migrate/20201027134205_add_immersible_to_organization.rb
@@ -1,0 +1,5 @@
+class AddImmersibleToOrganization < ActiveRecord::Migration[5.1]
+  def change
+    add_column :organizations, :immersible, :boolean, default: false
+  end
+end

--- a/lib/mumuki/domain/factories/organization_factory.rb
+++ b/lib/mumuki/domain/factories/organization_factory.rb
@@ -25,6 +25,7 @@ FactoryBot.define do
 
   factory :test_organization, parent: :public_organization do
     name { 'test' }
+    immersible { true }
     book { create(:book, name: 'test', slug: 'mumuki/mumuki-the-book') }
   end
 

--- a/lib/mumuki/domain/helpers/organization.rb
+++ b/lib/mumuki/domain/helpers/organization.rb
@@ -28,10 +28,6 @@ module Mumuki::Domain::Helpers::Organization
     name == 'base'
   end
 
-  def immersible?
-    public?
-  end
-
   def immersed_in?(other)
     immersible? && other.immersive? && target_audience == other.target_audience
   end

--- a/lib/mumuki/domain/locales/activerecord/en.yml
+++ b/lib/mumuki/domain/locales/activerecord/en.yml
@@ -28,3 +28,5 @@ en:
             base:
               consistent_public_login: 'A public organization can not restrict login methods'
               invalid_activity_range: 'The organization activity range are not valid'
+            immersible:
+              cannot_be_immersive: 'An organization cannot be immersible and immersive at the same time'

--- a/lib/mumuki/domain/locales/activerecord/es.yml
+++ b/lib/mumuki/domain/locales/activerecord/es.yml
@@ -45,6 +45,8 @@ es:
             base:
               consistent_public_login: 'Una organización pública no puede restringir los métodos de login'
               invalid_activity_range: 'La fecha de deshabilitación no puede ser anterior a la de inicio del recorrido'
+            immersible:
+              cannot_be_immersive: 'Una organización no puede ser inmersible e inmersiva a la vez'
     models:
       exercise:
         one: Ejercicio

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201019191036) do
+ActiveRecord::Schema.define(version: 20201027134205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -315,8 +315,9 @@ ActiveRecord::Schema.define(version: 20201019191036) do
     t.text "theme", default: "{}", null: false
     t.text "profile", default: "{}", null: false
     t.integer "progressive_display_lookahead"
-    t.boolean "incognito_mode_enabled"
     t.integer "target_audience", default: 0
+    t.boolean "incognito_mode_enabled"
+    t.boolean "immersible", default: false
     t.index ["book_id"], name: "index_organizations_on_book_id"
     t.index ["name"], name: "index_organizations_on_name", unique: true
   end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -342,6 +342,14 @@ describe Organization, organization_workspace: :test do
       it { expect(one.immersed_in? other_immersive).to be true }
       it { expect(one.immersed_in? other_non_immersive).to be false }
     end
+
+    context 'cannot be immersive' do
+      let(:orga) { build(:organization, immersible: true) }
+      before { orga.update(immersive: true) }
+
+      it { expect(orga.valid?).to be false }
+      it { expect(orga.errors[:immersible]).not_to be_nil }
+    end
   end
 
   describe 'lookahead' do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -264,8 +264,18 @@ describe Organization, organization_workspace: :test do
   end
 
   describe '#immersible?' do
-    context 'current public' do
+    context 'current private' do
+      let(:one) { build(:organization, public: false) }
+      it { expect(one.immersible?).to be false }
+    end
+
+    context 'current public, not immersible' do
       let(:one) { build(:organization, public: true) }
+      it { expect(one.immersible?).to be false }
+    end
+
+    context 'current public, immersible' do
+      let(:one) { build(:organization, public: true, immersible: true) }
 
       let(:other_immersive) { build(:organization, immersive: true) }
       let(:other_non_immersive) { build(:organization, immersive: false) }
@@ -273,11 +283,6 @@ describe Organization, organization_workspace: :test do
       it { expect(one.immersible?).to be true }
       it { expect(one.immersed_in? other_immersive).to be true }
       it { expect(one.immersed_in? other_non_immersive).to be false }
-    end
-
-    context 'current private' do
-      let(:one) { build(:organization, public: false) }
-      it { expect(one.immersible?).to be false }
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -147,7 +147,7 @@ describe User, organization_workspace: :test do
   end
 
 
-  describe 'immeresive behaviour' do
+  describe 'immersive behaviour' do
     let(:student) { create :user }
 
     context 'when no granted organizations' do


### PR DESCRIPTION
Closes #144 

# :dart: Goal

Add immersible flag to organizations, replacing old `public?` alias.

# :memo: Details

* Flag is false by default.
* Test organization was made immersible, to preserve retrocompatibility.

# :warning: Considerations

After this is merged, all the public organizations will not be immersible anymore. Perhaps the code to make the selected ones immersible could be included in the migration.