### PR TITLE
Set parent_id as nil if assignment is recontextualized

### DIFF
--- a/lib/mumuki/domain/submission/base.rb
+++ b/lib/mumuki/domain/submission/base.rb
@@ -54,6 +54,7 @@ class Mumuki::Domain::Submission::Base
   def save_submission!(assignment)
     assignment.content = content
     if assignment.organization != Organization.current
+      assignment.dirty_parent_by_submission!
       assignment.organization = Organization.current
       assignment.parent_id = nil
     end

--- a/lib/mumuki/domain/submission/base.rb
+++ b/lib/mumuki/domain/submission/base.rb
@@ -54,7 +54,7 @@ class Mumuki::Domain::Submission::Base
   def save_submission!(assignment)
     assignment.content = content
     if assignment.organization != Organization.current
-      assignment.dirty_parent_by_submission!
+      assignment.dirty_parent_by_submission! if assignment.organization
       assignment.organization = Organization.current
       assignment.parent_id = nil
     end

--- a/lib/mumuki/domain/submission/base.rb
+++ b/lib/mumuki/domain/submission/base.rb
@@ -53,7 +53,10 @@ class Mumuki::Domain::Submission::Base
 
   def save_submission!(assignment)
     assignment.content = content
-    assignment.organization = Organization.current
+    if assignment.organization != Organization.current
+      assignment.organization = Organization.current
+      assignment.parent_id = nil
+    end
     assignment.save!
   end
 

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -57,6 +57,7 @@ describe Guide do
 
   describe '#clear_progress!' do
     let(:an_exercise) { create(:exercise) }
+    let(:guide) { create(:indexed_guide) }
     let(:test_organization) { create(:test_organization) }
 
     before do

--- a/spec/models/solution_spec.rb
+++ b/spec/models/solution_spec.rb
@@ -139,4 +139,26 @@ describe Mumuki::Domain::Submission::Solution, organization_workspace: :test do
       it { expect(assignment.expectation_results).to eq([binding: '<<custom>>', inspection: 'foo uses composition', result: :passed]) }
     end
   end
+
+  describe '#submit_solution!' do
+    let(:organization)  { create :organization }
+    let(:organization2) { create :organization, name: 'orga2', book: organization.book }
+    let(:user) { create :user }
+
+    before { organization.switch! }
+    let(:exercise) { create :indexed_exercise }
+    let(:guide) { exercise.guide }
+    let!(:assignment) { exercise.submit_solution!(user, content: 'foo') }
+
+    before do
+      organization2.switch!
+      exercise.submit_solution!(user, content: 'bar')
+      assignment.reload
+    end
+
+    it { expect(assignment.solution).to eq('bar') }
+    it { expect(assignment.parent).to_not eq(guide.progress_for(user, organization )) }
+    it { expect(assignment.parent).to     eq(guide.progress_for(user, organization2)) }
+    it { expect(guide.progress_for(user, organization)).to be_dirty_by_submission }
+  end
 end


### PR DESCRIPTION
This is probably not the cleanest solution but something like this is necessary because if we change assignments organization but we don't change its parent it remains attached to it and progress is never recalculated properly for that indicator