### PR TITLE
Adding role term acceptance methods

### DIFF
--- a/app/models/concerns/with_terms_acceptance.rb
+++ b/app/models/concerns/with_terms_acceptance.rb
@@ -7,6 +7,14 @@ module WithTermsAcceptance
     !has_accepted_all?(profile_terms)
   end
 
+  def has_role_terms_to_accept?
+    !has_accepted_all?(role_specific_terms)
+  end
+
+  def role_specific_terms
+    @role_specific_terms ||= Term.role_specific_terms_for(self)
+  end
+
   def forum_terms
     @forum_terms ||= Term.forum_related_terms
   end

--- a/lib/mumuki/domain/incognito.rb
+++ b/lib/mumuki/domain/incognito.rb
@@ -64,12 +64,12 @@ module Mumuki::Domain
     # Terms
     # ========
 
-    def accepted_profile_terms?
-      true
+    def has_forum_terms_to_accept?
+      false
     end
 
-    def accepted_forum_terms?
-      true
+    def has_profile_terms_to_accept?
+      false
     end
 
     def has_accepted?(term)

--- a/lib/mumuki/domain/incognito.rb
+++ b/lib/mumuki/domain/incognito.rb
@@ -64,14 +64,13 @@ module Mumuki::Domain
     # Terms
     # ========
 
-    def has_forum_terms_to_accept?
+    # It avoids role terms acceptance redirections
+    def has_role_terms_to_accept?
       false
     end
 
-    def has_profile_terms_to_accept?
-      false
-    end
-
+    # It makes terms UI to be shown as if no terms were accepted
+    # It does not force any term to be accepted though
     def has_accepted?(term)
       false
     end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -425,7 +425,6 @@ ActiveRecord::Schema.define(version: 20201027152806) do
     t.datetime "disabled_at"
     t.boolean "trusted_for_forum"
     t.string "avatar_type", default: "Avatar"
-    t.index ["avatar_type", "avatar_id"], name: "index_users_on_avatar_type_and_avatar_id"
     t.datetime "headmaster_terms_accepted_at"
     t.datetime "janitor_terms_accepted_at"
     t.datetime "moderator_terms_accepted_at"
@@ -434,6 +433,7 @@ ActiveRecord::Schema.define(version: 20201027152806) do
     t.datetime "privacy_terms_accepted_at"
     t.datetime "legal_terms_accepted_at"
     t.datetime "forum_terms_accepted_at"
+    t.index ["avatar_type", "avatar_id"], name: "index_users_on_avatar_type_and_avatar_id"
     t.index ["disabled_at"], name: "index_users_on_disabled_at"
     t.index ["last_organization_id"], name: "index_users_on_last_organization_id"
     t.index ["uid"], name: "index_users_on_uid", unique: true

--- a/spec/models/incognito_spec.rb
+++ b/spec/models/incognito_spec.rb
@@ -78,4 +78,21 @@ describe Mumuki::Domain::Incognito do
       it { expect(user.current_immersive_context_at(nil)).to be_nil }
     end
   end
+
+  describe 'terms context fooling' do
+    let!(:legal_term) { create(:term, scope: :legal, locale: :en) }
+    let!(:moderator_term) { create(:term, scope: :moderator, locale: :en) }
+
+    context 'no role terms to accept' do
+      it { expect(user.has_role_terms_to_accept?).to eq false }
+    end
+
+    context 'has_accepted? term' do
+      it { expect(user.has_accepted?(legal_term)).to eq false }
+    end
+
+    context 'profile_terms' do
+      it { expect(Term.profile_terms_for(user)).to eq [legal_term] }
+    end
+  end
 end


### PR DESCRIPTION
## Goal

Adding `has_role_terms_to_accept?` to check if the user needs to accept some role terms.
Also, it simplifies incognito terms related methods 