### PR TITLE
Consider only problem exercises have content to save as solution

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -126,7 +126,7 @@ class Assignment < Progress
   end
 
   def content=(content)
-    if content.present?
+    if exercise.solvable?
       self.solution = exercise.single_choice? ? exercise.choice_index_for(content) : content
     end
   end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -239,8 +239,8 @@ class Exercise < ApplicationRecord
     guide.pending_exercises(user)
   end
 
-  def reading?
-    is_a? ::Reading
+  def solvable?
+    is_a? ::Problem
   end
 
   private

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -468,6 +468,54 @@ describe Assignment, organization_workspace: :test do
     end
   end
 
+  describe 'content' do
+    let(:user) { create(:user) }
+    let(:guide) { create(:indexed_guide) }
+
+    let(:interactive) { create(:interactive) }
+    let(:playground) { create(:playground, guide: guide) }
+    let(:problem) { create(:problem) }
+    let(:reading) { create(:reading, guide: guide) }
+
+    context 'interactive' do
+      let(:assignment) { interactive.assignment_for(user) }
+
+      before { interactive.submit_try!(user, query: 'foo') }
+
+      it 'has no content' do
+        expect(assignment.solution).to be_nil
+      end
+    end
+
+    context 'playground has no content' do
+      let(:assignment) { playground.assignment_for(user) }
+
+      before { playground.submit_query!(user, query: 'foo') }
+
+      it 'has no content' do
+        expect(assignment.solution).to be_nil
+      end
+    end
+
+    context 'problem' do
+      let(:assignment) { problem.submit_solution!(user, content: 'foo') }
+
+      it 'has content' do
+        expect(assignment.solution).to eq 'foo'
+      end
+    end
+
+    context 'reading' do
+      let(:assignment) { reading.assignment_for(user) }
+
+      before { reading.submit_confirmation!(user) }
+
+      it 'has no content' do
+        expect(assignment.solution).to be_nil
+      end
+    end
+  end
+
   describe 'submission status' do
     let(:exercise) { create(:indexed_exercise) }
     let(:assignment) { create(:assignment, exercise: exercise, status: submission_status) }

--- a/spec/models/solution_spec.rb
+++ b/spec/models/solution_spec.rb
@@ -187,7 +187,7 @@ describe Mumuki::Domain::Submission::Solution, organization_workspace: :test do
       before { exercise.submit_solution!(user, content: '') }
 
       it { expect(assignment.reload.status).to eq :failed }
-      pending { expect(assignment.reload.solution).to be_empty }
+      it { expect(assignment.reload.solution).to be_empty }
     end
   end
 end


### PR DESCRIPTION
## :dart: Goal

Fix a bug where playground exercises could not be passed.

`Reading` and `Playground` exercises do not have content, while `Interactive` do not go through `content=`

I'm unaware if this fix will reintroduce the bug fixed at https://github.com/mumuki/mumuki-domain/commit/aa7d4f5291484e2a3a1e80eb3441888f6a3a7cf4