### PR TITLE
Feature add game mode

### DIFF
--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -10,6 +10,10 @@ class UserStats < ApplicationRecord
     self.stats_for(user).exp
   end
 
+  def self.game_mode_enabled_for?(user)
+    self.stats_for(user).game_mode_enabled?
+  end
+
   def add_exp!(points)
     self.exp += points
   end

--- a/db/migrate/20201217154538_add_game_mode_enabled_to_user_stats.rb
+++ b/db/migrate/20201217154538_add_game_mode_enabled_to_user_stats.rb
@@ -1,0 +1,5 @@
+class AddGameModeEnabledToUserStats < ActiveRecord::Migration[5.1]
+  def change
+    add_column :user_stats, :game_mode_enabled, :boolean
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201130163114) do
+ActiveRecord::Schema.define(version: 20201217154538) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -397,6 +397,7 @@ ActiveRecord::Schema.define(version: 20201130163114) do
     t.integer "exp", default: 0
     t.bigint "user_id"
     t.bigint "organization_id"
+    t.boolean "game_mode_enabled"
     t.index ["organization_id"], name: "index_user_stats_on_organization_id"
     t.index ["user_id"], name: "index_user_stats_on_user_id"
   end


### PR DESCRIPTION
## :dart: Goal

Let a user enable gamification for a particular organization. Closes https://github.com/mumuki/mumuki-domain/issues/171.

I believe calling this `Game Mode` is much more user-friendly than talking in terms of`Enable Gamification` or such.