### PR TITLE
Feature add uppercase mode

### DIFF
--- a/app/models/concerns/with_preferences.rb
+++ b/app/models/concerns/with_preferences.rb
@@ -1,0 +1,7 @@
+module WithPreferences
+  extend ActiveSupport::Concern
+
+  included do
+    composed_of :preferences, mapping: %w(uppercase_mode uppercase_mode), constructor: :from_attributes
+  end
+end

--- a/app/models/preferences.rb
+++ b/app/models/preferences.rb
@@ -1,0 +1,17 @@
+class Preferences
+  include ActiveModel::Model
+
+  def self.attributes
+    [:uppercase_mode]
+  end
+
+  attr_accessor *self.attributes
+
+  def self.from_attributes(*args)
+    new self.attributes.zip(args).to_h
+  end
+
+  def uppercase?
+    uppercase_mode
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
           Awardee,
           Disabling,
           WithTermsAcceptance,
+          WithPreferences,
           Mumuki::Domain::Helpers::User
 
   serialize :permissions, Mumukit::Auth::Permissions

--- a/db/migrate/20210111125810_add_uppercase_mode_to_user.rb
+++ b/db/migrate/20210111125810_add_uppercase_mode_to_user.rb
@@ -1,0 +1,5 @@
+class AddUppercaseModeToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :uppercase_mode, :boolean
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -482,6 +482,7 @@ ActiveRecord::Schema.define(version: 20210119190204) do
     t.datetime "legal_terms_accepted_at"
     t.datetime "forum_terms_accepted_at"
     t.boolean "banned_from_forum"
+    t.boolean "uppercase_mode"
     t.index ["avatar_type", "avatar_id"], name: "index_users_on_avatar_type_and_avatar_id"
     t.index ["disabled_at"], name: "index_users_on_disabled_at"
     t.index ["last_organization_id"], name: "index_users_on_last_organization_id"


### PR DESCRIPTION
## :dart: Goal

Add a `Preferences` object to store user preferences and add the first setting, `uppercase_mode`. Needed for https://github.com/mumuki/mumuki-laboratory/pull/1532.

## :spiral_notepad: Note for reviewers

This is very similar as to how submissions are embedded in assignments, still, please let me know if this is what you were expecting @flbulgarelli as we talked on that other pull request. I'll write some tests in the meantime.

Here is how this design works

```ruby
user = User.last
=> #<User:0x0000557776f0a878
 id: 5,
 uppercase_mode: false>

user.preferences
=> #<Preferences:0x000055d33ece4d20 @uppercase_mode=false>
```

```ruby
user = User.last
=> #<User:0x0000557776f0a878
 id: 5,
 uppercase_mode: false>

user.uppercase_mode=true
=> true

user.preferences
=> #<Preferences:0x000055d33ebe3d60 @uppercase_mode=true>
```

```ruby
user = User.last
=> #<User:0x0000557776f0a878
 id: 5,
 uppercase_mode: false>

preferences = Preferences.new
=> #<Preferences:0x00005606976672d8>

preferences.uppercase_mode = true
=> true

user.preferences = preferences
=> #<Preferences:0x00005606976672d8 @uppercase_mode=true>

user
=> #<User:0x0000557776f0a878
 id: 5,
 uppercase_mode: true>
```

```ruby
user = User.last
=> #<User:0x0000557776f0a878
 id: 5,
 uppercase_mode: true>

user.preferences.uppercase?
=> true
```
