### PR TITLE
Feature prevent manual content

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -29,7 +29,7 @@ class Exercise < ApplicationRecord
   defaults { self.submissions_count = 0 }
 
   def self.default_scope
-    where(manual_evaluation: false) if Organization.safe_current&.hide_manual_evaluation_content
+    where(manual_evaluation: false) if Organization.safe_current&.prevent_manual_evaluation_content
   end
 
   alias_method :progress_for, :assignment_for

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -28,6 +28,10 @@ class Exercise < ApplicationRecord
 
   defaults { self.submissions_count = 0 }
 
+  def self.default_scope
+    where(manual_evaluation: false) if Organization.safe_current&.hide_manual_evaluation_content
+  end
+
   alias_method :progress_for, :assignment_for
 
   serialize :choices, Array

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -207,7 +207,7 @@ class Organization < ApplicationRecord
     end
 
     def silenced?
-      !Mumukit::Platform::Organization.current? || current.silent?
+      !current? || current.silent?
     end
 
     def sync_key_id_field

--- a/db/migrate/20210119160440_add_prevent_manual_evaluation_content_to_organizations.rb
+++ b/db/migrate/20210119160440_add_prevent_manual_evaluation_content_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddPreventManualEvaluationContentToOrganizations < ActiveRecord::Migration[5.1]
+  def change
+    add_column :organizations, :prevent_manual_evaluation_content, :boolean
+  end
+end

--- a/lib/mumuki/domain/helpers/organization.rb
+++ b/lib/mumuki/domain/helpers/organization.rb
@@ -74,6 +74,10 @@ module Mumuki::Domain::Helpers::Organization
       Mumukit::Platform::Organization.current?
     end
 
+    def safe_current
+      current if current?
+    end
+
     def parse(json)
       json
         .slice(:name)

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -376,7 +376,7 @@ ActiveRecord::Schema.define(version: 20210119190204) do
     t.text "display_description"
     t.boolean "wins_page"
     t.boolean "immersible"
-    t.boolean "hide_manual_evaluation_content"
+    t.boolean "prevent_manual_evaluation_content"
     t.index ["book_id"], name: "index_organizations_on_book_id"
     t.index ["name"], name: "index_organizations_on_name", unique: true
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -376,6 +376,7 @@ ActiveRecord::Schema.define(version: 20210119190204) do
     t.text "display_description"
     t.boolean "wins_page"
     t.boolean "immersible"
+    t.boolean "hide_manual_evaluation_content"
     t.index ["book_id"], name: "index_organizations_on_book_id"
     t.index ["name"], name: "index_organizations_on_name", unique: true
   end

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -190,7 +190,7 @@ describe Guide do
     end
 
     context "under a organization that does not support manual evaluation", organization_workspace: :test do
-      before { Organization.current.update! hide_manual_evaluation_content: true }
+      before { Organization.current.update! prevent_manual_evaluation_content: true }
       it { expect(guide.exercises.count).to eq 1 }
     end
   end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Organization, organization_workspace: :test do
   let(:user) { create(:user) }
   let(:central) { create(:organization, name: 'central') }
+  let(:current) { Organization.find_by(name: 'test') }
 
   describe '.import_from_resource_h!' do
     let(:book) { create(:book) }
@@ -50,9 +51,19 @@ describe Organization, organization_workspace: :test do
   end
 
   describe '.current' do
-    let(:organization) { Organization.find_by(name: 'test') }
-    it { expect(organization).to_not be nil }
-    it { expect(organization).to eq Organization.current }
+    it { expect(current).to_not be nil }
+    it { expect(Organization.current).to eq current }
+  end
+
+  describe '.safe_current' do
+    context "with current organization" do
+      it { expect(Organization.safe_current).to eq current }
+    end
+
+    context "without current organization" do
+      before { Mumukit::Platform::Organization.leave! }
+      it { expect(Organization.safe_current).to be nil }
+    end
   end
 
   describe 'defaults' do


### PR DESCRIPTION
# :dart: Goal

To allow content with `manual_evaluation` to be used in organizations than don't have teachers and thus no one is going to evaluate the submissions. 

# :memo: Details

This PR introduces the `prevent_manual_evaluation_content` flag for organizations that won't manually evaluate submission.  When enabled, exercises with `manual_evaluation` are simply wiped locally.     

This PR relies on `default_scope`. Yes, I know that using it is largely discouraged (eg [here](https://andycroll.com/ruby/dont-use-default-scope/) and [here](https://stackoverflow.com/questions/25087336/why-is-using-the-rails-default-scope-often-recommend-against)). However, I think this is a case where it still applies, and using named scopes would require a huge refactor to the whole platform. 

Actually, I think it is good to completely ignore manual exercises in such contexts, like it were a soft delete. I can't think of a scenario where `unscoped` would be actually necessary, since you don't edit guides from an organization - you are either in a organization-less script or implicitly using `base`.   

# :soon: Future work

This feature may be subsumed by adaptive paths in the future, since it also deals with skipping exercises in some sense. 

# :back: Backward compatibility

This PR is completely backwards compatible.  

# :warning: Warnings

* `base` organization should never have this flag enabled. Otherwise, you won't be able to edit manual evaluation content :scream: 
* If manual evaluation exercises are not in the last position of the guide, numeration will get inconsistent. This PR does not tries to fix that - manual evaluation that needs to be used  in these contexts must place such exercises at last. 

   