### PR TITLE
Chore database optimization

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -263,6 +263,10 @@ class Assignment < Progress
     update! misplaced: value if value != misplaced?
   end
 
+  def self.build_for(user, exercise, organization)
+    Assignment.new submitter: user, exercise: exercise, organization: organization
+  end
+
   private
 
   def duplicates_key

--- a/app/models/concerns/guide_container.rb
+++ b/app/models/concerns/guide_container.rb
@@ -13,7 +13,8 @@ module GuideContainer
              :first_exercise,
              :next_exercise,
              :stats_for,
-             :exercises_count, to: :guide
+             :exercises_count,
+             :assignments_for, to: :guide
   end
 
   def index_usage!(organization = Organization.current)

--- a/app/models/concerns/with_assignments.rb
+++ b/app/models/concerns/with_assignments.rb
@@ -19,6 +19,7 @@ module WithAssignments
   end
 
   # TODO: When the organization is used in this one, please change guide.pending_exercises
+  # TODO: Please do the same on WithAssignmentsBatch
   def find_assignment_for(user, _organization)
     assignments.find_by(submitter: user)
   end

--- a/app/models/concerns/with_assignments_batch.rb
+++ b/app/models/concerns/with_assignments_batch.rb
@@ -9,10 +9,12 @@ module WithAssignmentsBatch
 
     return exercises.map { |it| block.call nil, it  } unless user
 
-    exercises = self.exercises
-    ActiveRecord::Associations::Preloader.new.preload(exercises, :assignments, Assignment.where(submitter: user))
+    pairs = exercises.map { |it| [it.id, [nil, it]] }.to_h
+    Assignment.where(submitter: user, exercise: exercises).each do |it|
+      pairs[it.exercise_id][0] = it
+    end
 
-    exercises.map { |it| block.call it.assignments.first, it }
+    pairs.values.map { |assignment, exercise| block.call assignment, exercise }
   end
 
   def statuses_for(user, organization = Organization.current)

--- a/app/models/concerns/with_assignments_batch.rb
+++ b/app/models/concerns/with_assignments_batch.rb
@@ -1,0 +1,29 @@
+# WithAssignmentsBatch mirrors the WithAssignment mixin
+# but implements operations in batches, so that they outperform
+# their counterparts
+module WithAssignmentsBatch
+  extend ActiveSupport::Concern
+
+  def find_assignments_for(user, _organization = Organization.current)
+    exercises = self.exercises
+    ActiveRecord::Associations::Preloader.new.preload(exercises, :assignments, Assignment.where(submitter: user))
+
+    if block_given?
+      exercises.map { |it| yield it.assignments.first, it }
+    else
+      exercises.map { |it| it.assignments.first }
+    end
+  end
+
+  def statuses_for(user, organization = Organization.current)
+    find_assignments_for user, organization do |it|
+      it&.status || Mumuki::Domain::Status::Submission::Pending
+    end
+  end
+
+  def assignments_for(user, organization = Organization.current)
+    find_assignments_for user, organization do |it, exercise|
+      it || user.build_assignment(exercise, organization)
+    end
+  end
+end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -62,6 +62,12 @@ class Guide < Content
         where('assignments.id is null')
   end
 
+  def assignments_for(user, organization = Organization.current)
+    exercises = self.exercises
+    ActiveRecord::Associations::Preloader.new.preload(exercises, :assignments, Assignment.where(submitter: user))
+    exercises.map { |it| it.assignments.first || user.build_assignment(it, organization) }
+  end
+
   def first_exercise
     exercises.first
   end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -6,7 +6,8 @@ class Guide < Content
 
   include WithStats,
           WithExpectations,
-          WithLanguage
+          WithLanguage,
+          WithAssignmentsBatch
 
   markdown_on :corollary, :sources, :learn_more, :teacher_info
 
@@ -60,25 +61,6 @@ class Guide < Content
                   #{Mumuki::Domain::Status::Submission::ManualEvaluationPending.to_i}
                 )").
         where('assignments.id is null')
-  end
-
-  def assignments_for(user, organization = Organization.current)
-    map_preloaded_assignments_for user, organization do |it, exercise|
-      it || user.build_assignment(exercise, organization)
-    end
-  end
-
-
-  def statuses_for(user, organization = Organization.current)
-    map_preloaded_assignments_for user, organization do |it|
-      it&.status || Mumuki::Domain::Status::Submission::Pending
-    end
-  end
-
-  def map_preloaded_assignments_for(user, _organization = Organization.current, &block)
-    exercises = self.exercises
-    ActiveRecord::Associations::Preloader.new.preload(exercises, :assignments, Assignment.where(submitter: user))
-    exercises.map { |it| block.call it.assignments.first, it }
   end
 
   def first_exercise

--- a/app/models/stats.rb
+++ b/app/models/stats.rb
@@ -11,6 +11,10 @@ class Stats
     failed + pending == 0
   end
 
+  def almost_done?
+    failed + pending <= 1
+  end
+
   def started?
     submitted > 0
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -50,18 +50,19 @@ class Topic < Content
   end
 
   def pending_lessons(user)
-    guides.
-      joins('left join public.exercises exercises
-                on exercises.guide_id = guides.id').
-      joins("left join public.assignments assignments
+    lessons
+      .includes(:guide)
+      .references(:guide)
+      .joins('left join exercises exercises on exercises.guide_id = guides.id')
+      .joins("left join assignments assignments
                 on assignments.exercise_id = exercises.id
                 and assignments.submitter_id = #{user.id}
                 and assignments.submission_status in (
                   #{Mumuki::Domain::Status::Submission::Passed.to_i},
                   #{Mumuki::Domain::Status::Submission::ManualEvaluationPending.to_i}
-                )").
-      where('assignments.id is null').
-      group('public.guides.id', 'lessons.number').map(&:lesson)
+                )")
+      .where('assignments.id is null')
+      .group('guides.id', 'lessons.number', 'lessons.id')
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -211,7 +211,7 @@ class User < ApplicationRecord
   end
 
   def build_assignment(exercise, organization)
-    assignments.build(exercise: exercise, organization: organization)
+    Assignment.build_for(self, exercise, organization)
   end
 
   def pending_siblings_at(content)

--- a/app/models/with_stats.rb
+++ b/app/models/with_stats.rb
@@ -1,7 +1,7 @@
 module WithStats
   def stats_for(user)
     return unless user.present?
-    Stats.from_statuses exercises.map { |it| it.status_for(user) }
+    Stats.from_statuses statuses_for(user)
   end
 
   def started?(user)

--- a/lib/mumuki/domain/incognito.rb
+++ b/lib/mumuki/domain/incognito.rb
@@ -107,7 +107,7 @@ module Mumuki::Domain
     end
 
     def build_assignment(exercise, organization)
-      Assignment.new exercise: exercise, organization: organization, submitter: self
+      Assignment.build_for(self, exercise, organization)
     end
 
     def pending_siblings_at(content)

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -21,6 +21,11 @@ describe Guide do
   describe '#assignments_for', organization_workspace: :test do
     let(:guide) { create(:guide, exercises: [create(:exercise), create(:exercise), create(:exercise)]) }
 
+    context "no user" do
+      it { expect(guide.assignments_for(nil).map(&:status)).to eq [:pending, :pending, :pending] }
+      it { expect(guide.find_assignments_for nil).to eq [nil, nil, nil] }
+    end
+
     context "no assignments" do
       it { expect(guide.assignments_for(user).map(&:status)).to eq [:pending, :pending, :pending] }
       it { expect(guide.find_assignments_for user).to eq [nil, nil, nil] }

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -41,6 +41,11 @@ describe Guide do
       end
     end
 
+    context "incognito user" do
+      it { expect(guide.assignments_for(Mumuki::Domain::Incognito).map(&:status)).to eq [:pending, :pending, :pending] }
+      it { expect(guide.find_assignments_for Mumuki::Domain::Incognito).to eq [nil, nil, nil] }
+    end
+
     context "no user" do
       it { expect(guide.assignments_for(nil).map(&:status)).to eq [:pending, :pending, :pending] }
       it { expect(guide.find_assignments_for nil).to eq [nil, nil, nil] }

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Guide do
-  let!(:extra_user) { create(:user, first_name: 'Ignatius', last_name: 'Reilly') }
+  let!(:user) { create(:user, first_name: 'Ignatius', last_name: 'Reilly') }
   let(:guide) { create(:guide) }
   let(:python) { create :language, name: 'python', extension: 'py', test_extension: 'py' }
 
@@ -16,6 +16,31 @@ describe Guide do
     let(:guide) { create(:guide, slug: 'fLbUlGaReLlI/MuMUkI-saMPle-gUIde') }
 
     it { expect(guide.slug).to eq('flbulgarelli/mumuki-sample-guide') }
+  end
+
+  describe '#assignments_for', organization_workspace: :test do
+    let(:guide) { create(:guide, exercises: [create(:exercise), create(:exercise), create(:exercise)]) }
+
+    context "no assignments" do
+      it { expect(guide.assignments_for(user).map(&:status)).to eq [:pending, :pending, :pending] }
+      it { expect(guide.find_assignments_for user).to eq [nil, nil, nil] }
+    end
+
+    context "one assignment" do
+      before { guide.exercises.first.submit_solution! user, content: 'something'  }
+      it { expect(guide.assignments_for(user).map(&:status)).to eq [:failed, :pending, :pending] }
+      it { expect(guide.find_assignments_for(user)[1..]).to eq [nil, nil] }
+    end
+
+    context "two assignments" do
+      before do
+        guide.exercises.take(2).each { |it| it.submit_solution! user, content: 'something' }
+      end
+
+      it { expect(guide.assignments_for(user).map(&:status)).to eq [:failed, :failed, :pending] }
+      it { expect(guide.find_assignments_for(user)[2..]).to eq [nil] }
+    end
+
   end
 
   describe '#destroy' do
@@ -64,23 +89,23 @@ describe Guide do
     before do
       test_organization.switch!
       guide.exercises = [an_exercise]
-      an_exercise.submit_solution! extra_user
+      an_exercise.submit_solution! user
     end
 
     context 'when progress is exclusively in one organization' do
       let(:another_exercise) { create(:exercise) }
 
       before do
-        another_exercise.submit_solution! extra_user
-        guide.clear_progress!(extra_user, test_organization)
+        another_exercise.submit_solution! user
+        guide.clear_progress!(user, test_organization)
       end
 
       it 'destroys the guides assignments for the given user and organization' do
-        expect(an_exercise.find_assignment_for(extra_user, test_organization)).to be_nil
+        expect(an_exercise.find_assignment_for(user, test_organization)).to be_nil
       end
 
       it 'does not destroy other guides assignments for the given user and organization' do
-        expect(another_exercise.find_assignment_for(extra_user, test_organization)).to be_truthy
+        expect(another_exercise.find_assignment_for(user, test_organization)).to be_truthy
       end
     end
 
@@ -89,12 +114,12 @@ describe Guide do
 
       before do
         another_organization.switch!
-        an_exercise.submit_solution! extra_user
-        guide.clear_progress!(extra_user, test_organization)
+        an_exercise.submit_solution! user
+        guide.clear_progress!(user, test_organization)
       end
 
       it 'destroys the guides assignments for the given user and organization' do
-        expect(an_exercise.find_assignment_for(extra_user, test_organization)).to be_nil
+        expect(an_exercise.find_assignment_for(user, test_organization)).to be_nil
       end
     end
   end

--- a/spec/models/stats_spec.rb
+++ b/spec/models/stats_spec.rb
@@ -5,6 +5,7 @@ describe Stats do
     let(:stats) { Stats.new(passed: 0, passed_with_warnings: 0, failed: 0, pending: 10, skipped: 0) }
     it { expect(stats.submitted).to eq 0 }
     it { expect(stats.done?).to be false }
+    it { expect(stats.almost_done?).to be false }
     it { expect(stats.started?).to be false }
   end
 
@@ -12,6 +13,24 @@ describe Stats do
     let(:stats) { Stats.new(passed: 3, passed_with_warnings: 2, failed: 1, pending: 3, skipped: 1) }
     it { expect(stats.submitted).to eq 6 }
     it { expect(stats.done?).to be false }
+    it { expect(stats.almost_done?).to be false }
+    it { expect(stats.started?).to be true }
+  end
+
+  context 'when someone has started and is almost done because of pending exercises' do
+    let(:stats) { Stats.new(passed: 3, passed_with_warnings: 2, failed: 0, pending: 1, skipped: 0) }
+    it { expect(stats.submitted).to eq 5 }
+    it { expect(stats.done?).to be false }
+    it { expect(stats.almost_done?).to be true }
+    it { expect(stats.started?).to be true }
+  end
+
+
+  context 'when someone has started and is almost done because of failing exercises' do
+    let(:stats) { Stats.new(passed: 3, passed_with_warnings: 2, failed: 1, pending: 0, skipped: 0) }
+    it { expect(stats.submitted).to eq 6 }
+    it { expect(stats.done?).to be false }
+    it { expect(stats.almost_done?).to be true }
     it { expect(stats.started?).to be true }
   end
 
@@ -19,6 +38,7 @@ describe Stats do
     let(:stats) { Stats.new(passed: 7, passed_with_warnings: 2, failed: 0, pending: 0, skipped: 1) }
     it { expect(stats.submitted).to eq 9 }
     it { expect(stats.done?).to be true }
+    it { expect(stats.almost_done?).to be true }
     it { expect(stats.started?).to be true }
   end
 end


### PR DESCRIPTION
# :dart: Goal

To prove new methods that allow database optimization in mumuki-laboratory. 

# :memo: Details

Each commit is enumerated according to its optimization number that uniquely identifies the change across both domain and laboratory repositories. Actual optimization results are shown in laboratory's PR. 

In particular, the following new methods were introduced: 

* `assignments_for`, `statuses_for` at `Guide`, which are the recommended ways now of fetching a bunch of assignments instead of mapping to individual fetches. They mimic the original `WithAssignments` API but in a pluralized fashion.
* `almost_done?` at `Stats`. Side note: this object should be renamed someday to `GuideStats`, `ProgressStats`, `GuideProgressStats` or something like that. Maybe it should be subsumed into indicators @julian-berbel @felipecalvo 

Also, the only truly locally optimized method was `pending_lessons` at chapter.    

# :book: Suggested lecture

If not familiar with, I suggest reading about `includes` and family. Here are some posts: 

* https://scoutapm.com/blog/activerecord-includes-vs-joins-vs-preload-vs-eager_load-when-and-where
* https://medium.com/@tadhao/joins-vs-preload-vs-includes-vs-eager-load-in-rails-5f721c44b3a9

Unfortunately I didn't found good sources about [Preloader](https://www.rubydoc.info/docs/rails/ActiveRecord/Associations/Preloader). I actually found it digging in gists and Stack Overflow

# :eyes:  See 

* https://github.com/mumuki/mumuki-laboratory/pull/1552