### PR TITLE
Use cache_accesor for organization permissions related methods

### DIFF
--- a/lib/mumuki/domain/helpers/user.rb
+++ b/lib/mumuki/domain/helpers/user.rb
@@ -81,6 +81,8 @@ module Mumuki::Domain::Helpers::User
     result.map { |org| Mumukit::Platform::Organization.find_by_name!(org) rescue nil }.compact
   end
 
+  cache_accessor :any_granted_organizations, :student_granted_organizations
+
   def has_student_granted_organizations?
     student_granted_organizations.present?
   end


### PR DESCRIPTION
This is minor, but as part of performance improvements, I think we should use `cache_accessor` more often.

In particular, `student_granted_organizations` is used in core features like immersive redirections and profile completion and it's totally cacheable.
Also, I was tempted to replace that Mumukit::Platform::Organization.find_by_name! for a Organization.where as Organization is being used in another places in this file, but I wanted to hear your opinion @flbulgarelli.