### PR TITLE
Add activity stats to UserStats

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -138,6 +138,10 @@ class Organization < ApplicationRecord
     self[:progressive_display_lookahead] = lookahead.to_i.positive? ? lookahead : nil
   end
 
+  def activity_start_date(default_date)
+    [default_date, in_preparation_until&.to_date].compact.max
+  end
+
   # ==============
   # Display fields
   # ==============

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -11,11 +11,12 @@ class UserStats < ApplicationRecord
   end
 
   def activity(date_range = nil)
+    date_filter = { submitted_at: date_range }.compact
     {
         exercises: {
             solved_count: organization_exercises
                               .joins(:assignments)
-                              .where(assignments: { top_submission_status: [:passed, :skipped], submitter: user }.merge_if_present(:submitted_at, date_range))
+                              .where(assignments: { top_submission_status: [:passed, :skipped], submitter: user }.merge(date_filter))
                               .count,
             count: organization_exercises.count},
 
@@ -32,17 +33,12 @@ class UserStats < ApplicationRecord
   private
 
   def messages_in_discussions(date_range = nil)
+    date_filter = { date: date_range }.compact
     Message.joins(:discussion)
-        .where({sender: user.uid, discussions: { organization: organization }}.merge_if_present(:date, date_range))
+        .where({sender: user.uid, discussions: { organization: organization }}.merge(date_filter))
   end
 
   def organization_exercises
     organization.book.exercises
-  end
-end
-
-class Hash
-  def merge_if_present(key, value)
-    value ? merge({ key => value }) : self
   end
 end

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -10,7 +10,39 @@ class UserStats < ApplicationRecord
     self.stats_for(user).exp
   end
 
+  def activity(date_range = nil)
+    {
+        exercises: {
+            solved_count: organization_exercises
+                              .joins(:assignments)
+                              .where(assignments: { top_submission_status: [:passed, :skipped], submitter: user }.merge_if_present(:submitted_at, date_range))
+                              .count,
+            count: organization_exercises.count},
+
+        messages: {
+            count: messages_in_discussions(date_range).count,
+            approved: messages_in_discussions(date_range).where(approved: true).count}
+    }
+  end
+
   def add_exp!(points)
     self.exp += points
+  end
+
+  private
+
+  def messages_in_discussions(date_range = nil)
+    Message.joins(:discussion)
+        .where({sender: user.uid, discussions: { organization: organization }}.merge_if_present(:date, date_range))
+  end
+
+  def organization_exercises
+    organization.book.exercises
+  end
+end
+
+class Hash
+  def merge_if_present(key, value)
+    value ? merge({ key => value }) : self
   end
 end

--- a/spec/models/user_stats_spec.rb
+++ b/spec/models/user_stats_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe UserStats, organization_workspace: :test do
+  let(:user) { create(:user) }
+  let(:stats) { UserStats.stats_for user }
+
+  describe '#activity' do
+    let(:activity) { stats.activity }
+    let(:another_user) { create(:user) }
+
+    context 'exercises' do
+      let(:book) { Organization.current.book }
+      let(:exercises) { create_list(:exercise, 4) }
+
+      let!(:chapter) do
+        create(:chapter,
+               book: book,
+               lessons: [
+                   create(:lesson, exercises: exercises.take(2) ),
+                   create(:lesson, exercises: exercises.drop(2) )])
+      end
+
+      before { reindex_current_organization! }
+
+      before do
+        exercises[0].submit_solution!(user, content: '').passed!
+        exercises[0].submit_solution!(user, content: '').failed!
+
+        assignment = exercises[1].submit_solution!(user, content: '')
+        assignment.update!(submitted_at: 2.days.until, status: 'skipped')
+
+        exercises[0].submit_solution!(another_user, content: '').passed!
+      end
+
+      context 'without date filter' do
+        it { expect(stats.activity[:exercises]).to eq(solved_count: 2, count: 4) }
+      end
+
+      context 'with date filter' do
+        it { expect(stats.activity(3.days.until..1.day.until)[:exercises]).to eq(solved_count: 1, count: 4) }
+      end
+    end
+
+    context 'messages' do
+      let(:problem) { create(:indexed_exercise) }
+      let(:discussion) { problem.discuss! user, title: 'Need help' }
+
+      before { discussion.submit_message!({content: 'Same issue here'}, another_user) }
+      before { discussion.submit_message!({content: 'I forgot to say this', date: 2.days.until}, user) }
+      before { discussion.submit_message!({content: 'Oh, this is the answer!', approved: true}, user) }
+
+      context 'without date filter' do
+        it { expect(stats.activity[:messages]).to eq(count: 2, approved: 1) }
+      end
+
+      context 'with date filter' do
+        it { expect(stats.activity(3.day.until..1.day.until)[:messages]).to eq(count: 1, approved: 0) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## :dart: Goal

Add methods to retrieve information needed for mumuki/mumuki-laboratory#1540.

## :memo: Details

This was added to `UserStats` to avoid cluttering (even more!) the `User` model. 

