### PR TITLE
Add enum-prefixed-translations

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -129,6 +129,12 @@ class ApplicationRecord < ActiveRecord::Base
     end
   end
 
+  def self.enum_prefixed_translations_for(selector)
+    send(selector.to_s.pluralize).map do |key, _|
+      [I18n.t("#{selector}_#{key}", default: key.to_sym), key]
+    end
+  end
+
   private
 
   def raise_foreign_key_error!


### PR DESCRIPTION
## :dart: Goal

Add a method for obtaining prefixed translations for enum selectors.

## :memo: Details

Its very common to use a similar idiom to transform an enum hash to an array pair to be used as an input for a select, for example. I've extracted to a method, adding as first option the prefixed translation and defaulting to the regular one in other case.
This is handy because if we have, let's say:

```
enum some_enum: [:a_value, :another_value]
enum other_enum: [:a_value, :yet_another_value]
```

we could not provide different translations for :a_value, despite that in different contexts the same word can be translated differently. With this method it would look for :some_enum_a_value translation and then try to use :a_value. 