### PR TITLE
Chore preferences

### DIFF
--- a/app/models/concerns/with_preferences.rb
+++ b/app/models/concerns/with_preferences.rb
@@ -4,4 +4,8 @@ module WithPreferences
   included do
     composed_of :preferences, mapping: %w(uppercase_mode uppercase_mode), constructor: :from_attributes
   end
+
+  def uppercase?
+    uppercase_mode
+  end
 end

--- a/app/models/concerns/with_target_audience.rb
+++ b/app/models/concerns/with_target_audience.rb
@@ -2,7 +2,7 @@ module WithTargetAudience
   extend ActiveSupport::Concern
 
   included do
-    enum target_audience: [:grown_ups, :kids]
+    enum target_audience: [:grown_ups, :kids, :kindergarten]
   end
 
   class_methods do

--- a/app/models/concerns/with_target_audience.rb
+++ b/app/models/concerns/with_target_audience.rb
@@ -2,7 +2,11 @@ module WithTargetAudience
   extend ActiveSupport::Concern
 
   included do
-    enum target_audience: [:grown_ups, :kids, :kindergarten]
+    enum target_audience: [:grown_ups, :primary, :kindergarten]
+  end
+
+  def kids?
+    target_audience.to_sym.in? [:primary, :kindergarten]
   end
 
   class_methods do

--- a/lib/mumuki/domain/incognito.rb
+++ b/lib/mumuki/domain/incognito.rb
@@ -84,6 +84,20 @@ module Mumuki::Domain
     end
 
     # ========
+    # Preferences
+    # ========
+
+    def preferences
+      Class.new do
+        class << self
+          def method_missing(_)
+            false
+          end
+        end
+      end
+    end
+
+    # ========
     # Visiting
     # ========
 

--- a/spec/models/with_target_audience.rb
+++ b/spec/models/with_target_audience.rb
@@ -1,20 +1,21 @@
 require 'spec_helper'
 
 describe WithTargetAudience do
-  let!(:kids_organization) { create(:organization, target_audience: :kids) }
+  let!(:kindergarten_organization) { create(:organization, target_audience: :kindergarten) }
   let!(:grown_ups_organization) { create(:organization, target_audience: :grown_ups, name: 'for_grown_ups') }
 
-  let!(:kids_avatars) { create_list(:avatar, 3, target_audience: :kids) }
+  let!(:kindergarten_avatars) { create_list(:avatar, 3, target_audience: :kindergarten) }
   let!(:grown_ups_avatars) { create_list(:avatar, 3, target_audience: :grown_ups) }
 
   let(:user) { create(:user) }
 
-  context '.with_current_audience' do
+  context '.with_current_audience_for' do
     context 'when there is not a current organization' do
       context 'and student has no granted organizations' do
         it { expect(Avatar.with_current_audience_for(user)).to be_empty }
       end
-      context 'and student has no granted organizations' do
+
+      context 'and student has a granted organization' do
         before { user.add_permission! :teacher, grown_ups_organization; user.save! }
 
         it { expect(Avatar.with_current_audience_for(user)).to eq grown_ups_avatars }
@@ -22,15 +23,16 @@ describe WithTargetAudience do
     end
 
     context 'when there is a current organization' do
-      before { kids_organization.switch! }
+      before { kindergarten_organization.switch! }
 
       context 'and student has no granted organizations' do
-        it { expect(Avatar.with_current_audience_for(user)).to eq kids_avatars }
+        it { expect(Avatar.with_current_audience_for(user)).to eq kindergarten_avatars }
       end
-      context 'and student has no granted organizations' do
+
+      context 'and student has a granted organization' do
         before { user.add_permission! :teacher, grown_ups_organization; user.save! }
 
-        it { expect(Avatar.with_current_audience_for(user)).to eq kids_avatars }
+        it { expect(Avatar.with_current_audience_for(user)).to eq kindergarten_avatars }
       end
     end
   end

--- a/spec/models/with_target_audience.rb
+++ b/spec/models/with_target_audience.rb
@@ -36,4 +36,17 @@ describe WithTargetAudience do
       end
     end
   end
+
+  context '#kids?' do
+    describe 'primary and kindergarten organizations are for kids' do
+      let(:primary_organization) { create(:organization, target_audience: :primary, name: 'for_primary_kids') }
+
+      it { expect(primary_organization.kids?).to be true }
+      it { expect(kindergarten_organization.kids?).to be true }
+    end
+
+    describe 'grown ups organizations are not for kids' do
+      it { expect(grown_ups_organization.kids?).to be false }
+    end
+  end
 end


### PR DESCRIPTION
## :dart: Goal

Make some preferences-related small changes needed by Laboratory.

## :memo: Details

* Adds `uppercase?` as a shorthand for `uppercase_mode`
* Kids organizations are now either `primary` or `kindergarten`. This is so we can auto-uppercase kindergarten organizations instead of relying on custom CSS. All current `kids` organizations will now be `primary`.
* Makes all preferences `false` for incognito user.

## :soon: Future work

I might just merge this other PR https://github.com/mumuki/mumuki-domain/pull/173 (and a few more changes) into this one.