### PR TITLE
Add currently_in_exam? method for incognito

### DIFF
--- a/lib/mumuki/domain/incognito.rb
+++ b/lib/mumuki/domain/incognito.rb
@@ -90,6 +90,9 @@ module Mumuki::Domain
     def visit!(*)
     end
 
+    def currently_in_exam?
+      false
+    end
     # ========
     # Progress
     # ========


### PR DESCRIPTION
Needed by https://github.com/mumuki/mumuki-laboratory/pull/1573

Incognito user needs to respond to that method in order to be able to access forum related routes without an error. It isn't actually allowed to access them, but with this one a proper error message is renderer. Tested in labo associated branch