### PR TITLE
Chore discussions exercises context

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -18,7 +18,7 @@ class Book < Content
   end
 
   def discussions_in_organization(organization = Organization.current)
-    Discussion.where(organization: organization).includes(exercise: [:language, :guide])
+    Discussion.where(organization: organization, item: organization.exercises).includes(exercise: [:language, :guide])
   end
 
   def first_chapter

--- a/lib/mumuki/domain/factories/book_factory.rb
+++ b/lib/mumuki/domain/factories/book_factory.rb
@@ -4,4 +4,17 @@ FactoryBot.define do
     description { Faker::Lorem.sentence(word_count: 30) }
     slug { "mumuki/mumuki-test-book-#{SecureRandom.uuid}" }
   end
+
+  factory :book_with_full_tree, parent: :book do
+    transient do
+      children_factor { 3 }
+      exercises { create_list(:exercise, children_factor) }
+      lessons { create_list(:lesson, children_factor, exercises: exercises) }
+      chapters { create_list(:chapter, children_factor, lessons: lessons) }
+    end
+
+    after(:build) do |book, evaluator|
+      book.chapters = evaluator.chapters
+    end
+  end
 end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -321,4 +321,37 @@ describe Book, organization_workspace: :test do
       end
     end
   end
+
+  describe 'discussions_in_organization' do
+    before { Organization.current.update! book: book }
+    before { reindex_current_organization! }
+
+    before { book.exercises.last.discuss!(user, {description: 'new discussion'}) }
+
+    let(:user) { create(:user) }
+    let(:book) { create(:book_with_full_tree) }
+    let(:another_book) { create(:book_with_full_tree) }
+
+    context 'in the same organization' do
+      context 'with same book' do
+        it { expect(book.discussions_in_organization.count).to eq 1 }
+      end
+
+      context 'when book changes' do
+        before { Organization.current.update! book: another_book }
+        before { reindex_current_organization! }
+
+        it { expect(another_book.discussions_in_organization.count).to eq 0 }
+      end
+    end
+
+    context 'in another organization with same book' do
+      let(:other_organization) { create(:organization, book: book) }
+      before { other_organization.switch! }
+      before { reindex_current_organization! }
+
+      it { expect(book.discussions_in_organization.count).to eq 0 }
+    end
+
+  end
 end


### PR DESCRIPTION
## :dart: Goal

To only show discussions for current organization exercises. Before this fix discussions for old exercises could still be reached but they gave an error because the exercise wasn't present in the organization.
I'm just filtering discussions based on organization exercises. The other option was to add soft deletion, but it was more cumbersome, required to take into consideration edge cases and wasn't too much of a performance improvement

## :back: Backwards compatibility

100%

## :soon: Future work

This works fine. Nevertheless it makes little sense to talk about book discussions when in fact they are organization discussions. I will address this later on, cuz this works and that refactor is not a priority right now