### PR TITLE
Feature split progress by organization

### DIFF
--- a/app/models/concerns/with_assignments.rb
+++ b/app/models/concerns/with_assignments.rb
@@ -19,7 +19,6 @@ module WithAssignments
   end
 
   # TODO: When the organization is used in this one, please change guide.pending_exercises
-  # TODO: Please do the same on WithAssignmentsBatch
   def find_assignment_for(user, organization)
     assignments.find_by(submitter: user, organization: organization)
   end

--- a/app/models/concerns/with_assignments.rb
+++ b/app/models/concerns/with_assignments.rb
@@ -20,8 +20,8 @@ module WithAssignments
 
   # TODO: When the organization is used in this one, please change guide.pending_exercises
   # TODO: Please do the same on WithAssignmentsBatch
-  def find_assignment_for(user, _organization)
-    assignments.find_by(submitter: user)
+  def find_assignment_for(user, organization)
+    assignments.find_by(submitter: user, organization: organization)
   end
 
   def status_for(user)

--- a/app/models/concerns/with_assignments_batch.rb
+++ b/app/models/concerns/with_assignments_batch.rb
@@ -4,13 +4,13 @@
 module WithAssignmentsBatch
   extend ActiveSupport::Concern
 
-  def find_assignments_for(user, _organization = Organization.current, &block)
+  def find_assignments_for(user, organization = Organization.current, &block)
     block = block_given? ? block : lambda { |it, _e| it }
 
     return exercises.map { |it| block.call nil, it  } unless user
 
     pairs = exercises.map { |it| [it.id, [nil, it]] }.to_h
-    Assignment.where(submitter: user, exercise: exercises).each do |it|
+    Assignment.where(submitter: user, organization: organization, exercise: exercises).each do |it|
       pairs[it.exercise_id][0] = it
     end
 

--- a/lib/mumuki/domain/factories/organization_factory.rb
+++ b/lib/mumuki/domain/factories/organization_factory.rb
@@ -29,7 +29,8 @@ FactoryBot.define do
     book { create(:book, name: 'test', slug: 'mumuki/mumuki-the-book') }
   end
 
-  factory :another_test_organization, parent: :test_organization, traits: [:skip_unique_name_validation] do
+  factory :another_test_organization, parent: :test_organization do
+    name { 'another-test' }
     book { create(:book, name: 'another-test', slug: 'mumuki/mumuki-another-book') }
   end
 

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -255,9 +255,9 @@ describe Assignment, organization_workspace: :test do
       before { assignment.update_column(:organization_id, nil) }
       before { exercise.submit_solution!(user, content: 'foo') }
 
-      it 'should persist what organization it was submitted in' do
-        expect(assignment.reload.organization).to eq Organization.current
-      end
+      it { expect(Assignment.count).to eq 2 }
+      it { expect(assignment.reload.organization).to be_nil }
+      it { expect(exercise.find_assignment_for(user, Organization.current)).to_not be_nil }
     end
 
     context 'when solution is submitted after the assignment was created' do

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -112,13 +112,12 @@ describe Guide do
   end
 
   describe '#clear_progress!' do
-    let(:an_exercise) { create(:exercise) }
-    let(:guide) { create(:indexed_guide) }
+    let(:an_exercise) { create(:indexed_exercise) }
+    let(:guide) { an_exercise.guide }
     let(:test_organization) { create(:test_organization) }
 
     before do
       test_organization.switch!
-      guide.exercises = [an_exercise]
       an_exercise.submit_solution! user
     end
 
@@ -140,7 +139,7 @@ describe Guide do
     end
 
     context 'when progress is in more than one organization' do
-      let(:another_organization) { create(:another_test_organization) }
+      let(:another_organization) { create(:another_test_organization, book: test_organization.book) }
 
       before do
         another_organization.switch!

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -150,6 +150,10 @@ describe Guide do
       it 'destroys the guides assignments for the given user and organization' do
         expect(an_exercise.find_assignment_for(user, test_organization)).to be_nil
       end
+
+      it 'does not destroy the guide\'s assignments for other organizations' do
+        expect(an_exercise.find_assignment_for(user, another_organization)).to_not be_nil
+      end
     end
   end
 

--- a/spec/models/solution_spec.rb
+++ b/spec/models/solution_spec.rb
@@ -149,6 +149,7 @@ describe Mumuki::Domain::Submission::Solution, organization_workspace: :test do
     let(:exercise) { create :indexed_exercise }
     let(:guide) { exercise.guide }
     let!(:assignment) { exercise.submit_solution!(user, content: 'foo') }
+    let(:new_assignment) { exercise.find_assignment_for(user, organization2) }
 
     context 'when old organization still has the exercise' do
       before do
@@ -158,10 +159,12 @@ describe Mumuki::Domain::Submission::Solution, organization_workspace: :test do
         assignment.reload
       end
 
-      it { expect(assignment.solution).to eq('bar') }
-      it { expect(assignment.parent).to_not eq(guide.progress_for(user, organization )) }
-      it { expect(assignment.parent).to     eq(guide.progress_for(user, organization2)) }
-      it { expect(guide.progress_for(user, organization)).to be_dirty_by_submission }
+      it { expect(assignment.solution).to eq('foo') }
+      it { expect(new_assignment.solution).to eq('bar') }
+      it { expect(assignment.parent).to eq(guide.progress_for(user, organization )) }
+      it { expect(new_assignment.parent).to eq(guide.progress_for(user, organization2)) }
+      it { expect(guide.progress_for(user, organization)).to_not be_dirty_by_submission }
+      it { expect(guide.progress_for(user, organization2)).to_not be_dirty_by_submission }
     end
 
     context 'when old organization has not got the exercise' do
@@ -176,9 +179,10 @@ describe Mumuki::Domain::Submission::Solution, organization_workspace: :test do
         assignment.reload
       end
 
-      it { expect(assignment.solution).to eq('bar') }
+      it { expect(assignment.solution).to eq('foo') }
+      it { expect(new_assignment.solution).to eq('bar') }
       it { expect(assignment.parent).to_not eq(guide.progress_for(user, organization )) }
-      it { expect(assignment.parent).to     eq(guide.progress_for(user, organization2)) }
+      it { expect(new_assignment.parent).to eq(guide.progress_for(user, organization2)) }
       it { expect(guide.progress_for(user, organization)).not_to be_dirty_by_submission }
     end
 


### PR DESCRIPTION
## :dart: Goal
To split progress by organization! :sparkles: 
## :memo: Details
Assignments will now only be searched for in the requested organization.

The `skip_unique_name_validation` trait in the `another_test_organization` factory would allow the organization object to be created but it would still prevent the organization from being persisted, which would break a test.

As for the rest of the tests, they are expected behavior changes!

## :warning: Dependencies
None.
## :back: Backwards compatibility
Yes.
## :soon: Future work
migration, and lots of testing!
