### PR TITLE
Chore organic messages

### DIFF
--- a/app/models/concerns/with_notifications.rb
+++ b/app/models/concerns/with_notifications.rb
@@ -2,7 +2,7 @@ module WithNotifications
   extend ActiveSupport::Concern
 
   def unread_messages
-    messages.where read: false
+    messages_in_organization.where read: false
   end
 
   def unread_notifications

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,6 +52,10 @@ class User < ApplicationRecord
     last_guide.try(:lesson)
   end
 
+  def messages_in_organization(organization = Organization.current)
+    messages.where('assignments.organization': organization)
+  end
+
   def passed_submissions_count_in(organization)
     assignments.where(top_submission_status: Mumuki::Domain::Status::Submission::Passed.to_i, organization: organization).count
   end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -29,6 +29,7 @@ describe Message, organization_workspace: :test do
       let!(:assignment) { problem.submit_solution! user, content: '' }
       let(:final_assignment) { Assignment.first }
       let(:message) { Message.first }
+      let(:other_organization) { create(:organization) }
 
       let!(:data) {
         {'exercise_id' => problem.id,
@@ -62,6 +63,9 @@ describe Message, organization_workspace: :test do
                            exercise: {bibliotheca_id: problem.bibliotheca_id},
                            organization: 'test' }
       it { expect(final_assignment.has_messages?).to be true }
+      it { expect(user.messages.count).to eq 1 }
+      it { expect(user.messages_in_organization.count).to eq 1 }
+      it { expect(user.messages_in_organization(other_organization).count).to eq 0 }
     end
 
     context 'when not last submission' do


### PR DESCRIPTION
## :dart: Goal

To allow to retrieve messages in the current organization for users

## :sound: Discussion

We should discuss if we actually want the notifications to be shown only for current organization. It's inline with everything else we are doing but in this case I'm not so sure.
It's not a discussion to have _in this PR_ though.

## :back: Backwards compatibility
:ok: 
