### PR TITLE
Feature add period dates to course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -35,6 +35,14 @@ class Course < ApplicationRecord
     end
   end
 
+  def ended?
+    !!period_end && period_end < DateTime.now
+  end
+
+  def started?
+    !!period_start && period_start < DateTime.now
+  end
+
   def infer_period_range!
     return if period_start || period_end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -36,11 +36,11 @@ class Course < ApplicationRecord
   end
 
   def ended?
-    !!period_end && period_end.past?
+    period_end.present? && period_end.past?
   end
 
   def started?
-    !!period_start && period_start.past?
+    period_start.present? && period_start.past?
   end
 
   def infer_period_range!

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -11,7 +11,7 @@ class Course < ApplicationRecord
 
   alias_attribute :name, :code
 
-  resource_fields :slug, :shifts, :code, :days, :period, :description
+  resource_fields :slug, :shifts, :code, :days, :period, :description, :period_start, :period_end
 
   def current_invitation
     invitations.where('expiration_date > ?', Time.now).first

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -36,11 +36,11 @@ class Course < ApplicationRecord
   end
 
   def ended?
-    !!period_end && period_end < DateTime.now
+    !!period_end && period_end.past?
   end
 
   def started?
-    !!period_start && period_start < DateTime.now
+    !!period_start && period_start.past?
   end
 
   def infer_period_range!

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -51,8 +51,8 @@ class Course < ApplicationRecord
 
     return nil unless year.between? 2014, (DateTime.now.year + 1)
 
-    self.period_start = DateTime.new(year, 1, 1)
-    self.period_end = DateTime.new(year, 12, 31)
+    self.period_start = DateTime.new(year).beginning_of_year
+    self.period_end = DateTime.new(year).end_of_year
   end
 
   def canonical_code

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -35,6 +35,18 @@ class Course < ApplicationRecord
     end
   end
 
+  def infer_period_range!
+    return if period_start || period_end
+
+    period =~ /^(\d{4})?/
+    year = $1.to_i
+
+    return nil unless year.between? 2014, (DateTime.now.year + 1)
+
+    self.period_start = DateTime.new(year, 1, 1)
+    self.period_end = DateTime.new(year, 12, 31)
+  end
+
   def canonical_code
     "#{period}-#{code}".downcase
   end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -167,7 +167,7 @@ class Discussion < ApplicationRecord
   end
 
   def being_accessed_by_moderator?
-    last_moderator_access_at.present? && last_moderator_access_at > Time.now - MODERATOR_REVIEW_AVERAGE_TIME
+    last_moderator_access_at.present? && last_moderator_access_at.future? - MODERATOR_REVIEW_AVERAGE_TIME
   end
 
   def last_moderator_access_visible_for?(user)

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -39,7 +39,7 @@ class Invitation < ApplicationRecord
   end
 
   def expired?
-    Time.now > expiration_date
+    expiration_date.past?
   end
 
   def unexpired

--- a/db/migrate/20210301210530_add_period_start_and_end_to_course.rb
+++ b/db/migrate/20210301210530_add_period_start_and_end_to_course.rb
@@ -1,0 +1,7 @@
+class AddPeriodStartAndEndToCourse < ActiveRecord::Migration[5.1]
+  def change
+    add_column :courses, :period_start, :datetime
+    add_column :courses, :period_end, :datetime
+  end
+
+end

--- a/lib/mumuki/domain/organization/settings.rb
+++ b/lib/mumuki/domain/organization/settings.rb
@@ -40,10 +40,10 @@ class Mumuki::Domain::Organization::Settings < Mumukit::Platform::Model
   end
 
   def disabled?
-    disabled_from.present? && disabled_from < Time.now
+    disabled_from.present? && disabled_from.past?
   end
 
   def in_preparation?
-    in_preparation_until.present? && in_preparation_until > Time.now
+    in_preparation_until.present? && in_preparation_until.future?
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -121,6 +121,8 @@ ActiveRecord::Schema.define(version: 20210302181654) do
     t.integer "organization_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "period_start"
+    t.datetime "period_end"
   end
 
   create_table "discussions", force: :cascade do |t|

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -21,6 +21,36 @@ describe 'CourseChanged', organization_workspace: :test do
   it { expect(course.period).to eq '2016' }
   it { expect(course.canonical_code).to eq '2016-k2003' }
 
+  describe 'status' do
+    context 'started' do
+      let(:course) { Course.new period_start: 1.day.ago }
+
+      it { expect(course.started?).to be true }
+      it { expect(course.ended?).to be false }
+    end
+
+    context 'not started' do
+      let(:course) { Course.new period_start: 1.day.since }
+
+      it { expect(course.started?).to be false }
+      it { expect(course.ended?).to be false }
+    end
+
+    context 'ended' do
+      let(:course) { Course.new period_end: 1.day.ago }
+
+      it { expect(course.started?).to be false }
+      it { expect(course.ended?).to be true }
+    end
+
+    context 'not ended' do
+      let(:course) { Course.new period_end: 1.day.since }
+
+      it { expect(course.started?).to be false }
+      it { expect(course.ended?).to be false }
+    end
+  end
+
   describe "#infer_period_range!" do
     before { course.infer_period_range! }
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -21,6 +21,59 @@ describe 'CourseChanged', organization_workspace: :test do
   it { expect(course.period).to eq '2016' }
   it { expect(course.canonical_code).to eq '2016-k2003' }
 
+  describe "#infer_period_range!" do
+    before { course.infer_period_range! }
+
+    context 'period and range start' do
+      let(:course) { Course.new period: '2021', period_start: DateTime.new(2018, 3, 1) }
+
+      it { expect(course.period_start).to eq DateTime.new(2018, 3, 1) }
+      it { expect(course.period_end).to be nil }
+    end
+
+    context 'period and range end' do
+      let(:course) { Course.new period: '2021', period_end: DateTime.new(2018, 7, 15) }
+
+      it { expect(course.period_start).to be nil }
+      it { expect(course.period_end).to eq DateTime.new(2018, 7, 15) }
+    end
+
+    context 'no separators' do
+      let(:course) { Course.new period: '20181C'}
+
+      it { expect(course.period_start).to eq DateTime.new(2018, 1, 1) }
+      it { expect(course.period_end).to eq DateTime.new(2018, 12, 31) }
+    end
+
+    context 'with separators' do
+      let(:course) { Course.new period: '2020-1C'}
+
+      it { expect(course.period_start).to eq DateTime.new(2020, 1, 1) }
+      it { expect(course.period_end).to eq DateTime.new(2020, 12, 31) }
+    end
+
+    context 'before foundation' do
+      let(:course) { Course.new period: '0000'}
+
+      it { expect(course.period_start).to be nil}
+      it { expect(course.period_end).to be nil }
+    end
+
+    context 'too into the future' do
+      let(:course) { Course.new period: '9999'}
+
+      it { expect(course.period_start).to be nil}
+      it { expect(course.period_end).to be nil }
+    end
+
+    context 'empty period foundation' do
+      let(:course) { Course.new period: nil }
+
+      it { expect(course.period_start).to be nil}
+      it { expect(course.period_end).to be nil }
+    end
+  end
+
   describe '#invite!' do
     context 'when an invitation has not been created yet' do
       it { expect(course.current_invitation).to be nil }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -96,14 +96,14 @@ describe 'CourseChanged', organization_workspace: :test do
       let(:course) { Course.new period: '20181C'}
 
       it { expect(course.period_start).to eq DateTime.new(2018, 1, 1) }
-      it { expect(course.period_end).to eq DateTime.new(2018, 12, 31) }
+      it { expect(course.period_end).to eq DateTime.new(2018).end_of_year }
     end
 
     context 'with separators' do
       let(:course) { Course.new period: '2020-1C'}
 
       it { expect(course.period_start).to eq DateTime.new(2020, 1, 1) }
-      it { expect(course.period_end).to eq DateTime.new(2020, 12, 31) }
+      it { expect(course.period_end).to eq DateTime.new(2020).end_of_year }
     end
 
     context 'before foundation' do

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -42,7 +42,7 @@ describe Discussion, organization_workspace: :test do
 
         it { expect(discussion.status).to eq :closed }
         it { expect(discussion.status_updated_by).to eq initiator }
-        it { expect(discussion.status_updated_at).to be < Time.now }
+        it { expect(discussion.status_updated_at).to be_past }
         it { expect(discussion.reachable_statuses_for initiator).to eq [] }
         it { expect(discussion.reachable_statuses_for moderator).to eq [:opened, :solved] }
         it { expect(discussion.reachable_statuses_for student).to eq [] }
@@ -91,7 +91,7 @@ describe Discussion, organization_workspace: :test do
         it { expect(discussion.status).to eq :solved }
         it { expect(discussion.reachable_statuses_for initiator).to eq [] }
         it { expect(discussion.status_updated_by).to eq moderator }
-        it { expect(discussion.status_updated_at).to be < Time.now }
+        it { expect(discussion.status_updated_at).to be_past }
         it { expect(discussion.reachable_statuses_for moderator).to eq [:opened, :closed] }
         it { expect(discussion.reachable_statuses_for student).to eq [] }
         it { expect(discussion.commentable_by? student).to be false }


### PR DESCRIPTION
# :dart: Goal

To add period start and end dates to  `Course` objects.

# :memo: Details

New - optional - fields were added and also a few methods for checking course status. 

# :back: Backwards compatibility

100% backwards compatible. A new method `infer_period_range!` was introduced to make population of those new fields easier. 
