### PR TITLE
Added approved_at/by to message model

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -54,9 +54,9 @@ class Message < ApplicationRecord
 
   def toggle_approved!(user)
     if approved?
-      update! approved: false, approved_at: nil, approved_by: nil
+      disapprove!
     else
-      update! approved: true, approved_at: Time.now, approved_by: user
+      approve!(user)
     end
   end
 
@@ -102,5 +102,15 @@ class Message < ApplicationRecord
     if message_data['submission_id'].present?
       Assignment.find_by(submission_id: message_data.delete('submission_id'))&.receive_answer! message_data
     end
+  end
+
+  private
+
+  def approve!(user)
+    update! approved: true, approved_at: Time.now, approved_by: user
+  end
+
+  def disapprove!
+    update! approved: false, approved_at: nil, approved_by: nil
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,6 +2,8 @@ class Message < ApplicationRecord
 
   belongs_to :discussion, optional: true
   belongs_to :assignment, foreign_key: :submission_id, primary_key: :submission_id, optional: true
+  belongs_to :approved_by, class_name: 'User', optional: true
+
   has_one :exercise, through: :assignment
 
   validates_presence_of :content, :sender
@@ -50,12 +52,20 @@ class Message < ApplicationRecord
     update! read: true
   end
 
-  def toggle_approved!
-    toggle! :approved
+  def toggle_approved!(user)
+    if approved?
+      update! approved: false, approved_at: nil, approved_by: nil
+    else
+      update! approved: true, approved_at: Time.now, approved_by: user
+    end
   end
 
   def toggle_not_actually_a_question!
     toggle! :not_actually_a_question
+  end
+
+  def approved?
+    approved_at?
   end
 
   def validated?

--- a/db/migrate/20210308145910_add_approbed_by_and_at_to_message.rb
+++ b/db/migrate/20210308145910_add_approbed_by_and_at_to_message.rb
@@ -1,0 +1,6 @@
+class AddApprobedByAndAtToMessage < ActiveRecord::Migration[5.1]
+  def change
+    add_column :messages, :approved_at, :datetime
+    add_reference :messages, :approved_by, index: true
+  end
+end

--- a/db/migrate/20210308145910_add_approved_by_and_at_to_message.rb
+++ b/db/migrate/20210308145910_add_approved_by_and_at_to_message.rb
@@ -1,4 +1,4 @@
-class AddApprobedByAndAtToMessage < ActiveRecord::Migration[5.1]
+class AddApprovedByAndAtToMessage < ActiveRecord::Migration[5.1]
   def change
     add_column :messages, :approved_at, :datetime
     add_reference :messages, :approved_by, index: true

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210119190204) do
+ActiveRecord::Schema.define(version: 20210308145910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -368,6 +368,9 @@ ActiveRecord::Schema.define(version: 20210119190204) do
     t.integer "discussion_id"
     t.boolean "approved", default: false
     t.boolean "not_actually_a_question", default: false
+    t.datetime "approved_at"
+    t.bigint "approved_by_id"
+    t.index ["approved_by_id"], name: "index_messages_on_approved_by_id"
   end
 
   create_table "notifications", force: :cascade do |t|

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -107,7 +107,7 @@ describe Discussion, organization_workspace: :test do
       end
 
       describe 'and that message gets approved' do
-        before { discussion.messages.last.update! approved: true }
+        before { discussion.messages.last.toggle_approved! moderator }
         before { discussion.reload }
 
         it { expect(discussion.has_validated_responses?).to be true }

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -55,7 +55,7 @@ describe Message, organization_workspace: :test do
       it { expect(Message.count).to eq 1 }
       it { expect(message.assignment).to_not be_nil }
       it { expect(message.assignment).to eq final_assignment }
-      it { expect(message.to_resource_h.except 'created_at', 'updated_at', 'date')
+      it { expect(message.to_resource_h.except 'created_at', 'updated_at', 'date', 'approved_at', 'approved_by_id')
              .to json_like submission_id: message.submission_id,
                            content: 'a',
                            sender: 'teacher@mumuki.org',


### PR DESCRIPTION
## :dart: Goal
Add `approved_at` and `approved_by` fields to `Message` to save moderator who approved it

## :memo: Details
This is convenient to filter and visualize moderators forum activity

## :warning: Dependencies
No one

## :back: Backwards compatibility
No problems

## :soon: Future work
For now we maintain approved field, we must to migrate DB and remove that field from model
