### PR TITLE
Feature delete user account

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -98,7 +98,7 @@ class ApplicationRecord < ActiveRecord::Base
 
       define_method("#{field_name}_matches?") do |token|
         actual_token = attribute(token_attribute)
-        actual_token.present? && token == actual_token && attribute(token_date_attribute) >= Time.now
+        actual_token.present? && token == actual_token && attribute(token_date_attribute)&.future?
       end
     end
   end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -88,13 +88,12 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   def self.with_temporary_token(field_name, duration = 2.hours)
-    this = self
     class_eval do
       token_attribute = field_name
       token_date_attribute = "#{field_name}_expiration_date"
 
       define_method("generate_#{field_name}!") do
-        update!(token_attribute => this.generate_secure_token, token_date_attribute => duration.from_now)
+        update!(token_attribute => self.class.generate_secure_token, token_date_attribute => duration.from_now)
       end
 
       define_method("#{field_name}_matches?") do |token|

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -97,7 +97,8 @@ class ApplicationRecord < ActiveRecord::Base
       end
 
       define_method("#{field_name}_matches?") do |token|
-        token == attribute(token_attribute) && attribute(token_date_attribute) >= Time.now
+        actual_token = attribute(token_attribute)
+        actual_token.present? && token == actual_token && attribute(token_date_attribute) >= Time.now
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
           WithTermsAcceptance,
           WithPreferences,
           Mumuki::Domain::Helpers::User
+          ActiveRecord::SecureToken
 
   serialize :permissions, Mumukit::Auth::Permissions
 
@@ -52,6 +53,12 @@ class User < ApplicationRecord
 
   def last_lesson
     last_guide.try(:lesson)
+  end
+
+  def generate_delete_account_token!
+    update!(
+        delete_account_token: self.class.generate_unique_secure_token,
+        delete_account_token_expiration: 2.hours.from_now)
   end
 
   def messages_in_organization(organization = Organization.current)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,6 @@ class User < ApplicationRecord
           WithTermsAcceptance,
           WithPreferences,
           Mumuki::Domain::Helpers::User
-          ActiveRecord::SecureToken
 
   serialize :permissions, Mumukit::Auth::Permissions
 
@@ -50,19 +49,10 @@ class User < ApplicationRecord
   PLACEHOLDER_IMAGE_URL = 'user_shape.png'.freeze
 
   resource_fields :uid, :social_id, :email, :permissions, :verified_first_name, :verified_last_name, *profile_fields
+  with_temporary_token :delete_account_token
 
   def last_lesson
     last_guide.try(:lesson)
-  end
-
-  def generate_delete_account_token!
-    update!(
-        delete_account_token: self.class.generate_unique_secure_token,
-        delete_account_token_expiration_date: 2.hours.from_now)
-  end
-
-  def delete_account_token_matches?(token)
-    token == delete_account_token && delete_account_token_expiration_date >= Time.now
   end
 
   def messages_in_organization(organization = Organization.current)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,11 @@ class User < ApplicationRecord
   def generate_delete_account_token!
     update!(
         delete_account_token: self.class.generate_unique_secure_token,
-        delete_account_token_expiration: 2.hours.from_now)
+        delete_account_token_expiration_date: 2.hours.from_now)
+  end
+
+  def delete_account_token_matches?(token)
+    token == delete_account_token && delete_account_token_expiration_date >= Time.now
   end
 
   def messages_in_organization(organization = Organization.current)

--- a/db/migrate/20210310195602_add_delete_account_token_to_user.rb
+++ b/db/migrate/20210310195602_add_delete_account_token_to_user.rb
@@ -1,0 +1,6 @@
+class AddDeleteAccountTokenToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :delete_account_token, :string
+    add_column :users, :delete_account_token_expiration_date, :datetime
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210308145910) do
+ActiveRecord::Schema.define(version: 20210310195602) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -512,6 +512,8 @@ ActiveRecord::Schema.define(version: 20210308145910) do
     t.datetime "forum_terms_accepted_at"
     t.boolean "banned_from_forum"
     t.boolean "uppercase_mode"
+    t.string "delete_account_token"
+    t.datetime "delete_account_token_expiration_date"
     t.index ["avatar_type", "avatar_id"], name: "index_users_on_avatar_type_and_avatar_id"
     t.index ["disabled_at"], name: "index_users_on_disabled_at"
     t.index ["last_organization_id"], name: "index_users_on_last_organization_id"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -671,30 +671,32 @@ describe User, organization_workspace: :test do
     it { expect(user_1.certificates_in_organization Organization.current).to contain_exactly certificate_1, certificate_3 }
   end
 
-  describe '#generate_delete_account_token!' do
-    let(:user) { create :user }
-    before { user.generate_delete_account_token! }
+  describe 'delete_account_token' do
+    describe '#generate_delete_account_token!' do
+      let(:user) { create :user }
+      before { user.generate_delete_account_token! }
 
-    it { expect(user.delete_account_token).to be_an_instance_of(String) }
-    it { expect(user.delete_account_token).to have_attributes(size: be > 10) }
-    it { expect(user.delete_account_token_expiration_date).to be_between(Time.now, 2.hours.since) }
-  end
-
-  describe '#delete_account_token_matches?' do
-    let(:expiration_date) { 2.days.from_now }
-    let(:user) { create :user, delete_account_token: 'secret333', delete_account_token_expiration_date: expiration_date }
-
-    context 'valid token' do
-      it { expect(user.delete_account_token_matches? 'secret333').to be_truthy }
+      it { expect(user.delete_account_token).to be_an_instance_of(String) }
+      it { expect(user.delete_account_token).to have_attributes(size: be > 10) }
+      it { expect(user.delete_account_token_expiration_date).to be_between(Time.now, 2.hours.since) }
     end
 
-    context 'invalid token' do
-      it { expect(user.delete_account_token_matches? 'badtoken').to be_falsey }
-    end
+    describe '#delete_account_token_matches?' do
+      let(:expiration_date) { 2.days.from_now }
+      let(:user) { create :user, delete_account_token: 'secret333', delete_account_token_expiration_date: expiration_date }
 
-    context 'expired token' do
-      let(:expiration_date) { 1.hour.ago }
-      it { expect(user.delete_account_token_matches? 'secret333').to be_falsey }
+      context 'valid token' do
+        it { expect(user.delete_account_token_matches? 'secret333').to be_truthy }
+      end
+
+      context 'invalid token' do
+        it { expect(user.delete_account_token_matches? 'badtoken').to be_falsey }
+      end
+
+      context 'expired token' do
+        let(:expiration_date) { 1.hour.ago }
+        it { expect(user.delete_account_token_matches? 'secret333').to be_falsey }
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -702,6 +702,11 @@ describe User, organization_workspace: :test do
         let(:expiration_date) { 1.hour.ago }
         it { expect(user.delete_account_token_matches? 'secret333').to be_falsey }
       end
+
+      context 'token with no expiration date' do
+        let(:expiration_date) { nil }
+        it { expect(user.delete_account_token_matches? 'secret333').to be_falsey }
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -671,12 +671,30 @@ describe User, organization_workspace: :test do
     it { expect(user_1.certificates_in_organization Organization.current).to contain_exactly certificate_1, certificate_3 }
   end
 
-  describe 'generate_delete_account_token!' do
+  describe '#generate_delete_account_token!' do
     let(:user) { create :user }
     before { user.generate_delete_account_token! }
 
     it { expect(user.delete_account_token).to be_an_instance_of(String) }
     it { expect(user.delete_account_token).to have_attributes(size: be > 10) }
-    it { expect(user.delete_account_token_expiration).to be_between(Time.now, 2.hours.since) }
+    it { expect(user.delete_account_token_expiration_date).to be_between(Time.now, 2.hours.since) }
+  end
+
+  describe '#delete_account_token_matches?' do
+    let(:expiration_date) { 2.days.from_now }
+    let(:user) { create :user, delete_account_token: 'secret333', delete_account_token_expiration_date: expiration_date }
+
+    context 'valid token' do
+      it { expect(user.delete_account_token_matches? 'secret333').to be_truthy }
+    end
+
+    context 'invalid token' do
+      it { expect(user.delete_account_token_matches? 'badtoken').to be_falsey }
+    end
+
+    context 'expired token' do
+      let(:expiration_date) { 1.hour.ago }
+      it { expect(user.delete_account_token_matches? 'secret333').to be_falsey }
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -671,4 +671,12 @@ describe User, organization_workspace: :test do
     it { expect(user_1.certificates_in_organization Organization.current).to contain_exactly certificate_1, certificate_3 }
   end
 
+  describe 'generate_delete_account_token!' do
+    let(:user) { create :user }
+    before { user.generate_delete_account_token! }
+
+    it { expect(user.delete_account_token).to be_an_instance_of(String) }
+    it { expect(user.delete_account_token).to have_attributes(size: be > 10) }
+    it { expect(user.delete_account_token_expiration).to be_between(Time.now, 2.hours.since) }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -689,6 +689,11 @@ describe User, organization_workspace: :test do
         it { expect(user.delete_account_token_matches? 'secret333').to be_truthy }
       end
 
+      context 'no token' do
+        before { user.update! delete_account_token: nil }
+        it { expect(user.delete_account_token_matches? nil).to be_falsey }
+      end
+
       context 'invalid token' do
         it { expect(user.delete_account_token_matches? 'badtoken').to be_falsey }
       end


### PR DESCRIPTION
## :dart: Goal

Add a temporary delete account token, as needed by #86.

## :soon: Future work

- [x] Temporary token behavior could be moved to a concern/mixin that takes the field name as parameter and generates both the token creation and check methods.
