### PR TITLE
Chore certificate programs dates

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -134,6 +134,19 @@ class ApplicationRecord < ActiveRecord::Base
     end
   end
 
+  def self.active_between(start_date_field, end_date_field, **options)
+    define_singleton_method(:active) do |actually_filter=true|
+      if actually_filter
+        self.where("(#{start_date_field} IS NULL OR #{start_date_field} < :now) AND (#{end_date_field} IS NULL OR #{end_date_field} > :now)", now: Time.now)
+      else
+        all
+      end
+    end
+
+    aliased_as = options.delete(:aliased_as)
+    singleton_class.send(:alias_method, aliased_as, :active) if aliased_as
+  end
+
   ## Partially implements resource-hash protocol, by
   ## defining `to_resource_h` and helper methods `resource_fields` and `slice_resource_h`
   ## using the given fields

--- a/app/models/certificate_program.rb
+++ b/app/models/certificate_program.rb
@@ -2,7 +2,7 @@ class CertificateProgram < ApplicationRecord
   belongs_to :organization
   has_many :certificates
 
-  scope :ongoing, -> { where("start_date > :now AND end_date < :now", now: Time.now) }
+  active_between :start_date, :end_date, aliased_as: :ongoing
 
   def friendly
     title

--- a/app/models/certificate_program.rb
+++ b/app/models/certificate_program.rb
@@ -2,6 +2,8 @@ class CertificateProgram < ApplicationRecord
   belongs_to :organization
   has_many :certificates
 
+  scope :ongoing, -> { where("start_date > :now AND end_date < :now", now: Time.now) }
+
   def friendly
     title
   end
@@ -23,8 +25,8 @@ class CertificateProgram < ApplicationRecord
   }
 </style>
 <!-- You can use interpolations like --
-  <%#= certificate.start_date %>
-  <%#= certificate.end_date %>
+  <%#= certificate.started_at %>
+  <%#= certificate.ended_at %>
   <%#= user.formal_first_name %>
   <%#= user.formal_last_name %>
   <%#= user.formal_full_name %>

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -21,6 +21,8 @@ class Organization < ApplicationRecord
   belongs_to :book
   has_many :usages
 
+  has_many :certificate_programs
+
   validates_presence_of :contact_email, :locale
   validates_presence_of :welcome_email_template, if: :greet_new_users?
   validates :name, uniqueness: true,
@@ -106,6 +108,10 @@ class Organization < ApplicationRecord
   def site_name
     warn "Don't use site_name. Use display_name instead"
     name
+  end
+
+  def ongoing_certificate_programs?
+    certificate_programs.ongoing.exists?
   end
 
   # Tells if the given user can

--- a/db/migrate/20210318194559_add_dates_to_certificate_program.rb
+++ b/db/migrate/20210318194559_add_dates_to_certificate_program.rb
@@ -1,0 +1,6 @@
+class AddDatesToCertificateProgram < ActiveRecord::Migration[5.1]
+  def change
+    add_column :certificate_programs, :start_date, :datetime
+    add_column :certificate_programs, :end_date, :datetime
+  end
+end

--- a/db/migrate/20210318195238_rename_certificate_dates.rb
+++ b/db/migrate/20210318195238_rename_certificate_dates.rb
@@ -1,0 +1,6 @@
+class RenameCertificateDates < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :certificates, :start_date, :started_at
+    rename_column :certificates, :end_date, :ended_at
+  end
+end

--- a/lib/mumuki/domain/factories/certificate_factory.rb
+++ b/lib/mumuki/domain/factories/certificate_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :certificate do
-    start_date { 1.month.ago }
-    end_date { 1.minute.ago }
+    started_at { 1.month.ago }
+    ended_at { 1.minute.ago }
     user { build :user, first_name: 'Jane', last_name: 'Doe' }
     certificate_program { build :certificate_program }
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210310195602) do
+ActiveRecord::Schema.define(version: 20210318195238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,14 +79,16 @@ ActiveRecord::Schema.define(version: 20210310195602) do
     t.bigint "organization_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "start_date"
+    t.datetime "end_date"
     t.index ["organization_id"], name: "index_certificate_programs_on_organization_id"
   end
 
   create_table "certificates", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "certificate_program_id"
-    t.datetime "start_date"
-    t.datetime "end_date"
+    t.datetime "started_at"
+    t.datetime "ended_at"
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/models/certificate_program_spec.rb
+++ b/spec/models/certificate_program_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe CertificateProgram, organization_workspace: :test do
+
+  let!(:certificate_program) { create(:certificate_program, end_date: certificate_program_end_date, start_date: certificate_program_start_date) }
+  let(:certificate_program_end_date) { nil }
+  let(:certificate_program_start_date) { nil }
+
+  context '.ongoing' do
+    context 'with no end or start_date' do
+      it { expect(CertificateProgram.ongoing.count).to eq 1 }
+    end
+
+    context 'with end_date in the future and no start_date' do
+      let(:certificate_program_end_date) { Time.now + 5.minutes }
+
+      it { expect(CertificateProgram.ongoing.count).to eq 1 }
+    end
+
+    context 'with end_date in the past and no start_date' do
+      let(:certificate_program_end_date) { Time.now - 5.minutes }
+
+      it { expect(CertificateProgram.ongoing.count).to eq 0 }
+    end
+
+    context 'with start_date in the past and no end_date' do
+      let(:certificate_program_start_date) { Time.now - 5.minutes }
+
+      it { expect(CertificateProgram.ongoing.count).to eq 1 }
+    end
+
+    context 'with start_date in the future and no end_date' do
+      let(:certificate_program_start_date) { Time.now + 5.minutes }
+
+      it { expect(CertificateProgram.ongoing.count).to eq 0 }
+    end
+
+    context 'with end_date in the future and start_date in the past' do
+      let(:certificate_program_end_date) { Time.now + 5.minutes }
+      let(:certificate_program_start_date) { Time.now - 5.minutes }
+
+      it { expect(CertificateProgram.ongoing.count).to eq 1 }
+    end
+
+    context 'with both end_date and start_date in the future' do
+      let(:certificate_program_end_date) { Time.now + 5.minutes }
+      let(:certificate_program_start_date) { Time.now + 5.minutes }
+
+      it { expect(CertificateProgram.ongoing.count).to eq 0 }
+    end
+
+    context 'with both end_date and start_date in the past' do
+      let(:certificate_program_end_date) { Time.now - 5.minutes }
+      let(:certificate_program_start_date) { Time.now - 5.minutes }
+
+      it { expect(CertificateProgram.ongoing.count).to eq 0 }
+    end
+
+    context 'with actually_filter disabled' do
+      let(:certificate_program_end_date) { Time.now - 5.minutes }
+      let(:certificate_program_start_date) { Time.now - 5.minutes }
+
+      it { expect(CertificateProgram.ongoing(false).count).to eq 1 }
+    end
+  end
+end
+

--- a/spec/models/certificate_program_spec.rb
+++ b/spec/models/certificate_program_spec.rb
@@ -6,7 +6,7 @@ describe CertificateProgram, organization_workspace: :test do
   let(:certificate_program_end_date) { nil }
   let(:certificate_program_start_date) { nil }
 
-  context '.ongoing' do
+  describe '.ongoing' do
     context 'with no end or start_date' do
       it { expect(CertificateProgram.ongoing.count).to eq 1 }
     end

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -6,8 +6,8 @@ describe Certificate, organization_workspace: :test do
 
   context '#template_locals' do
     let(:locals) { certificate.template_locals.to_struct }
-    it { expect(locals.certificate.start_date).to_not be_nil }
-    it { expect(locals.certificate.end_date).to_not be_nil }
+    it { expect(locals.certificate.started_at).to_not be_nil }
+    it { expect(locals.certificate.ended_at).to_not be_nil }
     it { expect(locals.user.formal_first_name).to eq 'Jane' }
     it { expect(locals.user.formal_last_name).to eq 'Doe' }
     it { expect(locals.user.formal_full_name).to eq 'Jane Doe' }

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -409,5 +409,25 @@ describe Organization, organization_workspace: :test do
         it { expect(organization.progressive_display_lookahead).to be 1 }
       end
     end
+
+    describe '#ongoing_certificate_programs?' do
+      let(:organization) { create(:organization) }
+
+      context 'with no certificate_programs in that organization' do
+        it { expect(organization.ongoing_certificate_programs?).to be false }
+      end
+
+      context 'with ongoing certificate_programs in that organization' do
+        let!(:certificate_program) { create(:certificate_program, organization: organization) }
+
+        it { expect(organization.reload.ongoing_certificate_programs?).to be true }
+      end
+
+      context 'with finished certificate_programs in that organization' do
+        let!(:certificate_program) { create(:certificate_program, organization: organization, end_date: 1.day.ago) }
+
+        it { expect(organization.reload.ongoing_certificate_programs?).to be false }
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -652,11 +652,13 @@ describe User, organization_workspace: :test do
 
   describe '#certificated_in?' do
     let(:user) { create :user, uid: 'test' }
+    let(:certificate_program_1) { create(:certificate_program, certificates: [certificate_1])}
+    let(:certificate_program_2) { create(:certificate_program, certificates: [certificate_2])}
     let(:certificate_1) { create :certificate, user: user }
     let(:certificate_2) { create :certificate, user: create(:user) }
 
-    it { expect(user.certificated_in? certificate_1).to eq true }
-    it { expect(user.certificated_in? certificate_2).to eq false }
+    it { expect(user.certificated_in? certificate_program_1).to eq true }
+    it { expect(user.certificated_in? certificate_program_2).to eq false }
   end
 
   describe '#certificates_in_organization' do


### PR DESCRIPTION
## :memo: Details
There are several little changes in this one.

First of all I'm introducing optional `start_date` and `end_date` for `CertificateProgram`s and I renamed `start_date` and `end_date` of `Certificate`s to `started_at` and `ended_at` because I think it is more semantic this way and to avoid attribute name repetition and make it clearer.
For a `Certificate`, `started_at` and `ended_at` represent the dates in which the `certified student` actually completed the program. 
For a `CertificateProgram`, `start_date` and `end_date` are optional and they only represent the start and end date of the whole program. A program without start_date means that it is ongoing since the moment it was created and without end_date means that it could be ongoing forever. Ideally each program should have a clear start and end, but I'm considering those cases just in case.

I've created a method in `application_record` for easily creating a scope which filters between two optional dates and allow it to receive a param to specify if the filter should be actually applied or not.

So `CertificateProgram.active(false)` won't actually filter anything, which may be useful _in the future_ :smile:.

I've also added the ability for an `organization` to know if there is any `ongoing_certificate_programs?` there. My idea is to show `My certificates` section only if there are ongoing_certificate_programs or the user was certified in that organization in the past. My intuition is that adding a section for something that you can't obtain, like a certificate it's not ideal. To discuss with @aguspina @lauramangifesta and @felipecalvo  


## :warning: Dependencies
None

## :back: Backwards compatibility
100%
