### PR TITLE
Chore exam registration registrees

### DIFF
--- a/app/models/exam_registration.rb
+++ b/app/models/exam_registration.rb
@@ -6,6 +6,7 @@ class ExamRegistration < ApplicationRecord
   has_and_belongs_to_many :exams
   has_many :authorization_requests, class_name: 'ExamAuthorizationRequest'
   has_and_belongs_to_many :registrees, class_name: 'User'
+  has_many :notifications, as: :target
 
   enum authorization_criterion_type: %i(none passed_exercises), _prefix: :authorization_criterion
 
@@ -23,12 +24,20 @@ class ExamRegistration < ApplicationRecord
     authorization_criterion.ensure_valid!
   end
 
-  def register!(users)
-    update! registrees: users
+  def notify_unnotified_registrees!
+    unnotified_registrees.each { |registree| notify_registree! registree }
   end
 
-  def start!
-    registrees.each &method(:notify_user!)
+  def unnotified_registrees?
+    unnotified_registrees.exists?
+  end
+
+  def register_users!(users)
+    users.each { |user| register! user }
+  end
+
+  def unnotified_registrees
+    registrees.where.not(id: Notification.notified_users_ids_for(self, self.organization))
   end
 
   def process_requests!
@@ -43,9 +52,17 @@ class ExamRegistration < ApplicationRecord
       ExamAuthorizationRequest.new(exam_registration: self, organization: organization)
   end
 
+  def register!(user)
+    registrees << user unless registered?(user)
+  end
+
+  def registered?(user)
+    registrees.include? user
+  end
+
   private
 
-  def notify_user!(user)
-    Notification.create! organization: organization, user: user, target: self
+  def notify_registree!(registree)
+    Notification.create! organization: organization, user: registree, target: self
   end
 end

--- a/app/models/exam_registration.rb
+++ b/app/models/exam_registration.rb
@@ -5,6 +5,7 @@ class ExamRegistration < ApplicationRecord
   belongs_to :organization
   has_and_belongs_to_many :exams
   has_many :authorization_requests, class_name: 'ExamAuthorizationRequest'
+  has_and_belongs_to_many :registrees, class_name: 'User'
 
   enum authorization_criterion_type: %i(none passed_exercises), _prefix: :authorization_criterion
 
@@ -22,8 +23,12 @@ class ExamRegistration < ApplicationRecord
     authorization_criterion.ensure_valid!
   end
 
-  def start!(users)
-    users.each &method(:notify_user!)
+  def register!(users)
+    update! registrees: users
+  end
+
+  def start!
+    registrees.each &method(:notify_user!)
   end
 
   def process_requests!

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,6 +3,11 @@ class Notification < ApplicationRecord
   belongs_to :organization
   belongs_to :target, polymorphic: true
 
+
+  scope :notified_users_ids_for, ->(target, organization=Organization.current) do
+    where(target: target, organization: organization).pluck(:user_id)
+  end
+
   def mark_as_read!
     update read: true
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -302,6 +302,12 @@ class User < ApplicationRecord
     certificates.where(certificate_program: certificate_program).exists?
   end
 
+  def certificate_in(certificate_program, certificate_h)
+    return if certificated_in?(certificate_program)
+    certificate = certificates.create certificate_h.merge(certificate_program: certificate_program)
+    UserMailer.certificate(certificate).deliver_later
+  end
+
   private
 
   def welcome_to_new_organizations!

--- a/db/migrate/20210330175706_create_exam_registration_user_join_table.rb
+++ b/db/migrate/20210330175706_create_exam_registration_user_join_table.rb
@@ -1,0 +1,8 @@
+class CreateExamRegistrationUserJoinTable < ActiveRecord::Migration[5.1]
+  def change
+    create_join_table :exam_registrations, :users do |t|
+      t.index :user_id
+      t.index :exam_registration_id
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210318195238) do
+ActiveRecord::Schema.define(version: 20210330175706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -201,6 +201,13 @@ ActiveRecord::Schema.define(version: 20210318195238) do
     t.bigint "exam_registration_id", null: false
     t.index ["exam_id"], name: "index_exam_registrations_exams_on_exam_id"
     t.index ["exam_registration_id"], name: "index_exam_registrations_exams_on_exam_registration_id"
+  end
+
+  create_table "exam_registrations_users", id: false, force: :cascade do |t|
+    t.bigint "exam_registration_id", null: false
+    t.bigint "user_id", null: false
+    t.index ["exam_registration_id"], name: "index_exam_registrations_users_on_exam_registration_id"
+    t.index ["user_id"], name: "index_exam_registrations_users_on_user_id"
   end
 
   create_table "exams", id: :serial, force: :cascade do |t|

--- a/spec/models/exam_registration_spec.rb
+++ b/spec/models/exam_registration_spec.rb
@@ -28,9 +28,17 @@ describe ExamRegistration, organization_workspace: :test do
     end
   end
 
+  describe '#register!' do
+    context 'properly register all users' do
+      before { registration.register!([user, other_user])}
+
+      it { expect(registration.registrees).to eq([user, other_user]) }
+    end
+  end
+
   describe '#start!' do
     context 'creates notifications for all users' do
-      before { registration.start! [user, other_user] }
+      before { registration.register!([user, other_user]); registration.start! }
 
       it { expect(user.notifications.size).to eq(1) }
       it { expect(other_user.notifications.size).to eq(1) }

--- a/spec/models/exam_registration_spec.rb
+++ b/spec/models/exam_registration_spec.rb
@@ -53,10 +53,17 @@ describe ExamRegistration, organization_workspace: :test do
   end
 
   describe '#notify_unnotified_registrees!' do
-    context 'creates notifications for all registrees' do
 
+    before do
+      registration.register_users!([user, other_user])
+    end
+
+    context 'before being actually executed' do
+      it { expect(registration.unnotified_registrees?).to be true }
+    end
+
+    context 'after being actually executed' do
       before do
-        registration.register_users!([user, other_user])
         registration.notify_unnotified_registrees!
       end
 
@@ -65,6 +72,7 @@ describe ExamRegistration, organization_workspace: :test do
         it { expect(other_user.notifications.count).to eq(1) }
         it { expect(registration.notifications.count).to eq(2) }
         it { expect(user.notifications.first.target).to eq(registration) }
+        it { expect(registration.unnotified_registrees?).to be false }
       end
 
       context 'only new registrees are notified' do
@@ -79,8 +87,10 @@ describe ExamRegistration, organization_workspace: :test do
         it { expect(other_user.notifications.count).to eq(1) }
         it { expect(yet_another_user.notifications.count).to eq(1) }
         it { expect(registration.notifications.count).to eq(3) }
+        it { expect(registration.unnotified_registrees?).to be false }
       end
     end
+
   end
 
   describe '#process_requests!' do


### PR DESCRIPTION
## :dart: Goal
We needed to actually save users that were registered in an ExamRegistration. The only bond was the Notification model and that was quite brittle.

## :back: Backwards compatibility
100%

