### PR TITLE
Feature mixed evaluation

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -249,18 +249,6 @@ class Exercise < ApplicationRecord
   private
 
   def evaluation_class
-    if manual_evaluation?
-      manual_evaluation_class
-    else
-      automated_evaluation_class
-    end
-  end
-
-  def manual_evaluation_class
-    Mumuki::Domain::Evaluation::Manual
-  end
-
-  def automated_evaluation_class
     Mumuki::Domain::Evaluation::Automated
   end
 

--- a/app/models/exercise/problem.rb
+++ b/app/models/exercise/problem.rb
@@ -33,7 +33,15 @@ class Problem < QueriableChallenge
   end
 
   def evaluation_criteria?
-    manual_evaluation? || expectations? || test.present?
+    manual_evaluation? || automated_evaluation?
+  end
+
+  def mixed_evaluation?
+    manual_evaluation? && automated_evaluation?
+  end
+
+  def automated_evaluation?
+    expectations? || test.present?
   end
 
   def expectations?

--- a/app/models/exercise/problem.rb
+++ b/app/models/exercise/problem.rb
@@ -48,6 +48,16 @@ class Problem < QueriableChallenge
     own_expectations.present? || own_custom_expectations.present?
   end
 
+  def evaluation_class
+    if mixed_evaluation?
+      Mumuki::Domain::Evaluation::Mixed
+    elsif manual_evaluation?
+      Mumuki::Domain::Evaluation::Manual
+    else
+      Mumuki::Domain::Evaluation::Automated
+    end
+  end
+
   # Sets the layout. This method accepts input_kids as a synonym of input_primary
   # for historical reasons
   def layout=(layout)

--- a/lib/mumuki/domain/evaluation.rb
+++ b/lib/mumuki/domain/evaluation.rb
@@ -3,3 +3,4 @@ end
 
 require_relative './evaluation/manual'
 require_relative './evaluation/automated'
+require_relative './evaluation/mixed'

--- a/lib/mumuki/domain/evaluation/mixed.rb
+++ b/lib/mumuki/domain/evaluation/mixed.rb
@@ -1,0 +1,12 @@
+class Mumuki::Domain::Evaluation::Mixed < Mumuki::Domain::Evaluation::Manual
+  def evaluate!(assignment, submission)
+    evaluation = submission.evaluate! assignment
+    if evaluation[:status].passed?
+      super
+    elsif evaluation[:status].passed_with_warnings?
+      evaluation.merge(status: Mumuki::Domain::Status::Submission::Failed)
+    else
+      evaluation
+    end
+  end
+end

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -5,7 +5,6 @@ describe Mumuki::Domain::Submission::Query do
   let(:user) { create(:user) }
 
   before do
-    expect_any_instance_of(Challenge).to receive(:automated_evaluation_class).and_return(Mumuki::Domain::Evaluation::Automated)
     allow_any_instance_of(Language).to receive(:run_query!).and_return(status: :passed, result: '5')
   end
 

--- a/spec/models/solution_spec.rb
+++ b/spec/models/solution_spec.rb
@@ -36,7 +36,6 @@ describe Mumuki::Domain::Submission::Solution, organization_workspace: :test do
 
   describe '#submit_solution!' do
 
-    before { expect_any_instance_of(Challenge).to receive(:automated_evaluation_class).and_return(Mumuki::Domain::Evaluation::Automated) }
     before { expect_any_instance_of(Language).to receive(:run_tests!).with(bridge_request).and_return(bridge_response) }
     let(:submission_attributes) { {} }
     let(:assignment) { exercise.submit_solution! user, submission_attributes }


### PR DESCRIPTION
# :dart: Goal

To introduce an specialization of manual evaluation that allows to do some automated checks before putting assignment into `manual_evaluation_pending` status. 

# :memo: Details

The mixed mode is activated when content has manual evaluation flag enabled, but also tests and/or expectations. As such, this mode - like with manual evaluation mode - only makes sense for `Problem`s. 

They logic it follows is quite simple: when a solution to a mixed content is submitted, it is evaluated an usual, but then:

* if status is red - `failed`, `errored` and so on - status is kept red
* if status is yellow, status is turn red - `failed` - too
* otherwise, the solution enters in dark blue - `manual_evaluation_pending` - state  

# :camera_flash: Screenshots

Captures taken from laboratory:

### When expectations fail

![Screenshot from 2021-04-07 12-26-00](https://user-images.githubusercontent.com/677436/113892657-9840ad80-979c-11eb-9145-005e2668905a.png)


### When expectations pass

![Screenshot from 2021-04-07 12-25-35](https://user-images.githubusercontent.com/677436/113892634-92e36300-979c-11eb-8cd4-77de1a60ccae.png)



# :back: Backwards compatibility

Mostly backwards compatible. I have removed two very odd, old methods, but they were not used in the platform aside of some tests 
