### PR TITLE
Feature next chapter

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -29,8 +29,4 @@ class Chapter < ApplicationRecord
   def structural_parent
     book
   end
-
-  def pending_siblings_for(user)
-    book.pending_chapters(user)
-  end
 end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -2,8 +2,8 @@ class Chapter < ApplicationRecord
   include WithStats
   include WithNumber
 
-  include SiblingsNavigation
   include TerminalNavigation
+  include SiblingsNavigation
 
   include FriendlyName
 

--- a/app/models/concerns/navigation/siblings_navigation.rb
+++ b/app/models/concerns/navigation/siblings_navigation.rb
@@ -12,10 +12,9 @@ module SiblingsNavigation
     structural_parent.structural_children
   end
 
-  #TODO reestablish this after indicators reliably linked to assignments
-  # def pending_siblings_for(user, organization=Organization.current)
-  #   siblings.reject { |it| it.progress_for(user, organization).completed? }
-  # end
+  def pending_siblings_for(user, organization=Organization.current)
+    siblings.reject { |it| it.progress_for(user, organization).completed? }
+  end
 
   # Names
 


### PR DESCRIPTION
~This is a work in progress! :warning:~

## :dart: Goal
Making chapters siblings navigable in order to allow suggesting following chapter once one is completed.
## :memo: Details
Right now this has a small side effect changing the chapter section of breadcrumb from something like `Programación Funcional` to `3. Programación Funcional`; it's easily overridable but I figured I'd ask for opinions first

Also, since I'm restoring pending_siblings for chapters through indicators, should I go ahead and restore it for other contents as well?
## :warning: Dependencies
None.
## :back: Backwards compatibility
Yes.
## :soon: Future work
None?