### PR TITLE
Use only lesson exercises in user_stats activity

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -33,7 +33,7 @@ class Organization < ApplicationRecord
   after_create :reindex_usages!
   after_update :reindex_usages!, if: lambda { |user| user.saved_change_to_book_id? }
 
-  has_many :guides, through: 'usages', source: 'item', source_type: 'Guide'
+  has_many :guides, -> { where 'usages.parent_item_type' => 'Lesson' }, through: 'usages', source: 'item', source_type: 'Guide'
   has_many :exercises, through: :guides
   has_many :assignments, through: :exercises
   has_many :exams

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -43,6 +43,6 @@ class UserStats < ApplicationRecord
   end
 
   def organization_exercises
-    @organization_exercises ||= organization.exercises
+    @organization_exercises ||= organization.book.exercises
   end
 end

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -43,6 +43,6 @@ class UserStats < ApplicationRecord
   end
 
   def organization_exercises
-    @organization_exercises ||= organization.book.exercises
+    @organization_exercises ||= organization.exercises
   end
 end

--- a/spec/models/user_stats_spec.rb
+++ b/spec/models/user_stats_spec.rb
@@ -63,6 +63,18 @@ describe UserStats, organization_workspace: :test do
 
       end
 
+      context 'for organization with complements' do
+        let!(:complement) { create(:complement, exercises: [create(:exercise), create(:exercise)]) }
+        before { reindex_current_organization! }
+
+        it { expect(stats.activity[:exercises]).to eq(solved_count: 2, count: 4) }
+      end
+
+      context 'for organization with exams' do
+        let!(:exam) { create(:exam, exercises: [create(:exercise), create(:exercise)]) }
+
+        it { expect(stats.activity[:exercises]).to eq(solved_count: 2, count: 4) }
+      end
     end
 
     context 'messages' do


### PR DESCRIPTION
## :dart: Goal
Only take into account lesson related exercises

## :memo: Details
There is a problem with the current implementation of user_stats activity. It's using `organization.exercises` which is the fastest way of accessing organization exercises but it has the problem that it's taking into account exams and complements as well, because it's being joined through usages.

There are two alternatives:

- The easy one is the one I've implemented. Using `organization.book.exercises`. This one has the problem that the query is heavier. It's going through the entire content tree to get the exercises.
- The correct one would be to implement an organization method that gets book exercises through usages (using parent_item_type = 'Lesson'). I think in fact, that we could just update `exercises` organization method instead of creating a new one. It's being used in places where it makes sense to access only book exercises.

What do you think @julian-berbel @felipecalvo?

## :back: Backwards compatibility
100%