### PR TITLE
Feature soft delete forum messages

### DIFF
--- a/app/models/concerns/with_soft_deletion.rb
+++ b/app/models/concerns/with_soft_deletion.rb
@@ -9,4 +9,8 @@ module WithSoftDeletion
   def soft_delete!(motive, deleter)
     update! deletion_motive: motive, deleted_by: deleter, deleted_at: Time.now
   end
+
+  def deleted?
+    deleted_at.present?
+  end
 end

--- a/app/models/concerns/with_soft_deletion.rb
+++ b/app/models/concerns/with_soft_deletion.rb
@@ -1,0 +1,8 @@
+module WithSoftDeletion
+  extend ActiveSupport::Concern
+
+  included do
+    enum deletion_motive: %i(self_deleted inappropriate_content shares_solution discloses_personal_information)
+    belongs_to :deleted_by, class_name: 'User', optional: true
+  end
+end

--- a/app/models/concerns/with_soft_deletion.rb
+++ b/app/models/concerns/with_soft_deletion.rb
@@ -5,4 +5,8 @@ module WithSoftDeletion
     enum deletion_motive: %i(self_deleted inappropriate_content shares_solution discloses_personal_information)
     belongs_to :deleted_by, class_name: 'User', optional: true
   end
+
+  def soft_delete!(motive, deleter)
+    update! deletion_motive: motive, deleted_by: deleter, deleted_at: Time.now
+  end
 end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -190,6 +190,6 @@ class Discussion < ApplicationRecord
   private
 
   def messages_by_updated_at(direction = :desc)
-    messages.reorder(updated_at: direction)
+    messages.where(deletion_motive: nil).reorder(updated_at: direction)
   end
 end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -38,6 +38,10 @@ class Discussion < ApplicationRecord
     end
   end
 
+  def visible_messages
+    messages.where.not(deletion_motive: :self_deleted).or(messages.where(deletion_motive: nil))
+  end
+
   def try_solve!
     if opened?
       update! status: reachable_statuses_for(initiator).first
@@ -73,7 +77,7 @@ class Discussion < ApplicationRecord
   end
 
   def last_message_date
-    messages.last&.created_at || created_at
+    visible_messages.last&.created_at || created_at
   end
 
   def friendly
@@ -125,11 +129,11 @@ class Discussion < ApplicationRecord
   end
 
   def has_messages?
-    messages.exists? || description.present?
+    visible_messages.exists? || description.present?
   end
 
   def responses_count
-    messages.where.not(sender: initiator.uid).count
+    visible_messages.where.not(sender: initiator.uid).count
   end
 
   def has_responses?

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,5 @@
 class Message < ApplicationRecord
+  include WithSoftDeletion
 
   belongs_to :discussion, optional: true
   belongs_to :assignment, foreign_key: :submission_id, primary_key: :submission_id, optional: true

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -44,7 +44,8 @@ class Message < ApplicationRecord
   end
 
   def to_resource_h
-    as_json(except: [:id, :type, :discussion_id, :approved, :not_actually_a_question],
+    as_json(except: [:id, :type, :discussion_id, :approved, :approved_at, :approved_by_id,
+                     :not_actually_a_question, :deletion_motive, :deleted_at, :deleted_by_id],
             include: {exercise: {only: [:bibliotheca_id]}})
         .merge(organization: Organization.current.name)
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -11,7 +11,6 @@ class Message < ApplicationRecord
   validates_presence_of :submission_id, :unless => :discussion_id?
 
   after_save :update_counters_cache!
-  after_destroy :update_counters_cache!
 
   markdown_on :content
 

--- a/db/migrate/20210318191512_add_deletion_fields_to_message.rb
+++ b/db/migrate/20210318191512_add_deletion_fields_to_message.rb
@@ -1,0 +1,7 @@
+class AddDeletionFieldsToMessage < ActiveRecord::Migration[5.1]
+  def change
+    add_column :messages, :deletion_motive, :integer
+    add_column :messages, :deleted_at, :datetime
+    add_reference :messages, :deleted_by, index: true
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -381,7 +381,11 @@ ActiveRecord::Schema.define(version: 20210330175706) do
     t.boolean "not_actually_a_question", default: false
     t.datetime "approved_at"
     t.bigint "approved_by_id"
+    t.integer "deletion_motive"
+    t.datetime "deleted_at"
+    t.bigint "deleted_by_id"
     t.index ["approved_by_id"], name: "index_messages_on_approved_by_id"
+    t.index ["deleted_by_id"], name: "index_messages_on_deleted_by_id"
   end
 
   create_table "notifications", force: :cascade do |t|

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -6,7 +6,7 @@ describe Message, organization_workspace: :test do
       {'exercise_id' => 1,
        'submission_id' => 'abcdef1',
        'message' => {
-         'sender' => 'aguspina87@gmail.com',
+         'sender' => 'student@mumuki.org',
          'content' => 'a',
          'created_at' => '1/1/1'}} }
 
@@ -14,7 +14,7 @@ describe Message, organization_workspace: :test do
       {'submission_id' => 'abcdef1',
        'content' => 'a',
        'created_at' => '1/1/1',
-       'sender' => 'aguspina87@gmail.com'} }
+       'sender' => 'student@mumuki.org'} }
 
     let(:parsed_comment) { Message.parse_json(data) }
 
@@ -55,7 +55,7 @@ describe Message, organization_workspace: :test do
       it { expect(Message.count).to eq 1 }
       it { expect(message.assignment).to_not be_nil }
       it { expect(message.assignment).to eq final_assignment }
-      it { expect(message.to_resource_h.except 'created_at', 'updated_at', 'date', 'approved_at', 'approved_by_id')
+      it { expect(message.to_resource_h.except 'created_at', 'updated_at', 'date')
              .to json_like submission_id: message.submission_id,
                            content: 'a',
                            sender: 'teacher@mumuki.org',


### PR DESCRIPTION
## :dart: Goal

Let forum messages be soft deleted.

## :memo: Details

The following deletion motives are introduced:
* `self_delete`, intended for users who want to delete their own message;
* `inappropriate_content`,
* `shares_correct_solution` and
* `discloses_personal_information`, all three intended for moderators

Besides the deletion motive, we will also be persisting who deleted the message (`deleted_by`) and when (`deleted_at`)

