### PR TITLE
Chore retenantize

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,4 @@ group :test do
 end
 
 gem 'codeclimate-test-reporter', :group => :test, :require => nil
+gem 'mumukit-platform', github: 'mumuki/mumukit-platform', branch: 'chore-untenantize'

--- a/lib/mumuki/domain/helpers/organization.rb
+++ b/lib/mumuki/domain/helpers/organization.rb
@@ -44,6 +44,10 @@ module Mumuki::Domain::Helpers::Organization
     Mumukit::Platform.laboratory.organic_url_for(name, path)
   end
 
+  def retenantized_url_for(tenantized_path)
+    Mumukit::Platform.laboratory.retenantize_in(name, tenantized_path)
+  end
+
   def url
     url_for '/'
   end

--- a/spec/lib/organization_helpers_spec.rb
+++ b/spec/lib/organization_helpers_spec.rb
@@ -212,6 +212,17 @@ describe Mumukit::Platform::Organization do
         it { expect(organization.url_for '/zaraza').to eq 'http://localmumuki.io/orga/zaraza' }
       end
     end
+    describe '#retenantized_url_for' do
+      context 'with subdomain mapping' do
+        it { expect(organization.retenantized_url_for 'a_route/nested').to eq 'http://orga.localmumuki.io/a_route/nested' }
+      end
+
+      context 'with path mapping' do
+        before { allow_any_instance_of(Mumukit::Platform::Application::Organic).to receive(:organization_mapping).and_return(Mumukit::Platform::OrganizationMapping::Path) }
+
+        it { expect(organization.retenantized_url_for 'other_orga/a_route/nested').to eq 'http://localmumuki.io/orga/a_route/nested' }
+      end
+    end
     describe '#domain' do
       it { expect(organization.domain).to eq 'orga.localmumuki.io' }
     end


### PR DESCRIPTION
## :dart: Goal
Allow organizations to retenantize tenantized paths.
This is useful for the `immersive redirection` feature

## :warning: Dependencies
https://github.com/mumuki/mumukit-platform/pull/46

## :back: Backwards compatibility
100%

