### PR TITLE
Chore abbreviated name

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -211,6 +211,10 @@ class User < ApplicationRecord
     name.split.map(&:first).map(&:capitalize).join(' ')
   end
 
+  def abbreviated_name
+    "#{first_name} #{last_name.first.capitalize + '.' if last_name.present?}".strip
+  end
+
   def progress_at(content, organization)
     Indicator.find_or_initialize_by(user: self, organization: organization, content: content)
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -568,7 +568,7 @@ describe User, organization_workspace: :test do
       context 'with several names' do
         let(:user) { create(:user, first_name: 'John George', last_name: 'Doe Foo') }
 
-        it { expect(user.name_initials).to eq 'J G D F' }
+        it { expect(user.abbreviated_name).to eq 'John George D.' }
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -540,6 +540,38 @@ describe User, organization_workspace: :test do
       it { expect(user.name_initials).to eq '' }
     end
 
+    describe '#abbreviated_name' do
+      context 'with first_name and last_name' do
+        let(:user) { create(:user, first_name: 'John', last_name: 'Doe') }
+
+        it { expect(user.abbreviated_name).to eq 'John D.' }
+      end
+
+      context 'with just first_name' do
+        let(:user) { create(:user, first_name: 'John', last_name: nil) }
+
+        it { expect(user.abbreviated_name).to eq 'John' }
+      end
+
+      context 'with just last_name' do
+        let(:user) { create(:user, first_name: nil, last_name: 'Doe') }
+
+        it { expect(user.abbreviated_name).to eq 'D.' }
+      end
+
+      context 'with no first_name or last_name' do
+        let(:user) { create(:user, first_name: nil, last_name: nil) }
+
+        it { expect(user.abbreviated_name).to eq '' }
+      end
+
+      context 'with several names' do
+        let(:user) { create(:user, first_name: 'John George', last_name: 'Doe Foo') }
+
+        it { expect(user.name_initials).to eq 'J G D F' }
+      end
+    end
+
     context 'with several names' do
       let(:user) { create(:user, first_name: 'John George', last_name: 'Doe Foo') }
 


### PR DESCRIPTION
## :dart: Goal
To show abbreviated name instead of user full name in forum messages for anonymity reasons

## :memo: Details
You'll notice that in the last test it returns John George D. instead of John George D. F. . This was intentional to reveal as fewer information possible. It could be easily fixed if you prefer the second case, re-using code from `name_initials` method.

## :back: Backwards compatibility
100%
