### PR TITLE
Avoid showing blank formal_name

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -283,11 +283,11 @@ class User < ApplicationRecord
   end
 
   def formal_first_name
-    verified_first_name || first_name
+    verified_first_name.presence || first_name
   end
 
   def formal_last_name
-    verified_last_name || last_name
+    verified_last_name.presence || last_name
   end
 
   def formal_full_name


### PR DESCRIPTION
## :dart: Goal
Avoid showing empty string if a verified_name is "" instead of nil