### PR TITLE
Fix exam breaks on next for

### DIFF
--- a/app/models/concerns/navigation/terminal_navigation.rb
+++ b/app/models/concerns/navigation/terminal_navigation.rb
@@ -18,4 +18,8 @@ module TerminalNavigation
   def siblings
     []
   end
+
+  def next_for(_user)
+    nil
+  end
 end

--- a/spec/models/exam_spec.rb
+++ b/spec/models/exam_spec.rb
@@ -20,7 +20,15 @@ describe Exam, organization_workspace: :test do
         it { expect(ExamAuthorization.where(exam: exam).count).to eq 0 }
       end
     end
+  end
 
+  describe '#next_for' do
+    let(:exam) { create(:exam) }
+
+    context 'does not break when asked for next' do
+      it { expect { exam.next_for(user) }.to_not raise_error }
+      it { expect(exam.next_for(user)).to be_nil }
+    end
   end
 
   describe '#validate_accessible_for!' do


### PR DESCRIPTION
## :dart: Goal
Fix exams breaking when one of their exercises is asked for next content.

## :memo: Details
When implementing next chapter button I added a flow that would ask a content's parent for the next available content. Since exams didn't understand message `next_for` this caused them to break when this flow came into action.

Setting TerminalNavigation objects as having no next content fixes this problem.

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.
