### PR TITLE
Fix summary access problem

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -29,7 +29,7 @@ class ApplicationRecord < ActiveRecord::Base
   def self.serialize_symbolized_hash_array(*keys)
     keys.each do |field|
       serialize field
-      define_method(field) { self[field]&.map { |it| it.symbolize_keys } }
+      define_method(field) { self[field]&.map { |it| it.deep_symbolize_keys } }
     end
   end
 

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -420,6 +420,14 @@ describe Assignment, organization_workspace: :test do
 
       it { expect(assignment.affable_test_results).to eq [{status: :failed, title: 'title', result: 'Expected <10>'}]  }
     end
+
+    context 'it works with string keys too' do
+      let(:test_results) do
+        [ { 'status' => :failed, 'summary' => { 'type' => 'some_error', 'message' => 'something went wrong!' }, 'title' => 'some title', 'result' => 'some result' } ]
+      end
+
+      it { expect(assignment.affable_test_results).to eq [{ result: "some result", status: :failed, summary: "something went wrong!", title: "some title" }] }
+    end
   end
 
   describe '#sanitized_affable_test_results' do


### PR DESCRIPTION
## :dart: Goal
Make `affable_test_results` work with string-keyed hashes as well.

## :memo: Details
Honestly, this isn't a great solution; It's _very_ problem-specific and I expect a similar issue could arise again. For the time being though, it fixes our issue.

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.
