### PR TITLE
Prevent manual evaluation exercises on with_pending_assignments_for too

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -29,7 +29,7 @@ class Exercise < ApplicationRecord
   defaults { self.submissions_count = 0 }
 
   def self.default_scope
-    where(manual_evaluation: false) if Organization.safe_current&.prevent_manual_evaluation_content
+    where(manual_evaluation: false) if hide_manual_evaluation?
   end
 
   alias_method :progress_for, :assignment_for
@@ -256,6 +256,10 @@ class Exercise < ApplicationRecord
     layouts.keys[0]
   end
 
+  def self.hide_manual_evaluation?
+    Organization.safe_current&.prevent_manual_evaluation_content
+  end
+
   def self.with_pending_assignments_for(user, relation)
     relation.
         joins("left join assignments assignments
@@ -266,6 +270,7 @@ class Exercise < ApplicationRecord
                   #{Mumuki::Domain::Status::Submission::Passed.to_i},
                   #{Mumuki::Domain::Status::Submission::ManualEvaluationPending.to_i}
                 )").
-        where('assignments.id is null')
+        where('assignments.id is null').
+        where(('exercises.manual_evaluation = false' if hide_manual_evaluation?))
   end
 end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -81,13 +81,13 @@ describe Topic do
 
     before { organization.switch!.reindex_usages! }
 
-    context 'on organization with prevent_manual_evaluation' do
+    context 'on organization with prevent_manual_evaluation_content' do
       let(:organization) { create :organization, prevent_manual_evaluation_content: true, book: book }
 
       it { expect(pending_lessons_count).to eq 0 }
     end
 
-    context 'on organization without' do
+    context 'on organization without prevent_manual_evaluation_content' do
       let(:organization) { create :organization, book: book }
 
       it { expect(pending_lessons_count).to eq 1 }

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -72,4 +72,25 @@ describe Topic do
     end
   end
 
+  describe '#pending_lessons' do
+    let(:book) { create :book, topics: [topic] }
+    let(:topic) { create :topic, lessons: [lesson] }
+    let(:lesson) { create :lesson, exercises: [create(:exercise, manual_evaluation: true)] }
+    let(:user) { create :user }
+    let(:pending_lessons_count) { topic.pending_lessons(user).to_a.count }
+
+    before { organization.switch!.reindex_usages! }
+
+    context 'on organization with prevent_manual_evaluation' do
+      let(:organization) { create :organization, prevent_manual_evaluation_content: true, book: book }
+
+      it { expect(pending_lessons_count).to eq 0 }
+    end
+
+    context 'on organization without' do
+      let(:organization) { create :organization, book: book }
+
+      it { expect(pending_lessons_count).to eq 1 }
+    end
+  end
 end


### PR DESCRIPTION
## :dart: Goal
Pending lessons calculation is not considering whether manual_evaluation exercises should be accounted for or not. This PR is aimed at fixing that.

## :memo: Details
An alternative to this pr should be properly starting using indicators for siblings navigation

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
Adding some tests ~here and~ in labo.
