### PR TITLE
Add clear_progress_for! to user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,8 @@ class User < ApplicationRecord
 
   has_many :notifications
   has_many :assignments, foreign_key: :submitter_id
+  has_many :indicators
+  has_many :user_stats, class_name: 'UserStats'
   has_many :messages, -> { order(created_at: :desc) }, through: :assignments
 
   has_many :submitted_exercises, through: :assignments, class_name: 'Exercise', source: :exercise

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -319,7 +319,7 @@ class User < ApplicationRecord
 
     target_assignments = assignments.where(location)
 
-    messages.where(discussion_id: nil, assignment: target_assignments).delete_all
+    messages.where(assignment: target_assignments).delete_all
 
     target_assignments.delete_all
     indicators.where(location).delete_all

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -312,6 +312,14 @@ class User < ApplicationRecord
     UserMailer.certificate(certificate).deliver_later
   end
 
+  def clear_progress_for!(organization)
+    location = { organization: organization }.compact
+
+    assignments.where(location).delete_all
+    indicators.where(location).delete_all
+    user_stats.where(location).delete_all
+  end
+
   private
 
   def welcome_to_new_organizations!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -317,7 +317,11 @@ class User < ApplicationRecord
   def clear_progress_for!(organization)
     location = { organization: organization }.compact
 
-    assignments.where(location).delete_all
+    target_assignments = assignments.where(location)
+
+    messages.where(discussion_id: nil, assignment: target_assignments).delete_all
+
+    target_assignments.delete_all
     indicators.where(location).delete_all
     user_stats.where(location).delete_all
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -743,4 +743,40 @@ describe User, organization_workspace: :test do
       end
     end
   end
+
+  describe '#clear_progress_for!' do
+    let(:user) { create :user }
+
+    let(:organization_1) { create :organization, name: 'orga-1' }
+    let(:organization_2) { create :organization, name: 'orga-2' }
+    let(:exercise_1) { create :indexed_exercise }
+    let(:exercise_2) { create :indexed_exercise }
+
+    before do
+      organization_1.switch!
+      exercise_1.submit_solution!(user).passed!
+      organization_2.switch!
+      exercise_2.submit_solution!(user).passed!
+    end
+
+    it { expect(user.assignments.count).to eq 2 }
+    it { expect(user.indicators.count).to eq 6 }
+    it { expect(user.user_stats.count).to eq 2 }
+
+    context 'on clearing progress for a specific organization' do
+      before { user.clear_progress_for!(organization_1) }
+
+      it { expect(user.assignments.count).to eq 1 }
+      it { expect(user.indicators.count).to eq 3 }
+      it { expect(user.user_stats.count).to eq 1 }
+    end
+
+    context 'on general progress clear' do
+      before { user.clear_progress_for!(nil) }
+
+      it { expect(user.assignments.count).to eq 0 }
+      it { expect(user.indicators.count).to eq 0 }
+      it { expect(user.user_stats.count).to eq 0 }
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -757,11 +757,11 @@ describe User, organization_workspace: :test do
     before do
       organization_1.switch!
       assignment_1 = exercise_1.submit_solution!(user).tap(&:passed!)
-      create :message, sender: user, assignment: assignment_1, discussion_id: nil
+      create :message, sender: user, assignment: assignment_1
       organization_2.switch!
       assignment_2 = exercise_2.submit_solution!(user).tap(&:passed!)
-      create :message, sender: user, assignment: assignment_2, discussion_id: nil
-      create :message, sender: user, assignment: assignment_1, discussion_id: 1
+      create :message, sender: user, assignment: assignment_2
+      create :message, sender: user, discussion_id: 1
     end
 
     it { expect(user.assignments.count).to eq 2 }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -752,16 +752,22 @@ describe User, organization_workspace: :test do
     let(:exercise_1) { create :indexed_exercise }
     let(:exercise_2) { create :indexed_exercise }
 
+    let(:messages_count) { Message.count }
+
     before do
       organization_1.switch!
-      exercise_1.submit_solution!(user).passed!
+      assignment_1 = exercise_1.submit_solution!(user).tap(&:passed!)
+      create :message, sender: user, assignment: assignment_1, discussion_id: nil
       organization_2.switch!
-      exercise_2.submit_solution!(user).passed!
+      assignment_2 = exercise_2.submit_solution!(user).tap(&:passed!)
+      create :message, sender: user, assignment: assignment_2, discussion_id: nil
+      create :message, sender: user, assignment: assignment_1, discussion_id: 1
     end
 
     it { expect(user.assignments.count).to eq 2 }
     it { expect(user.indicators.count).to eq 6 }
     it { expect(user.user_stats.count).to eq 2 }
+    it { expect(messages_count).to eq 3 }
 
     context 'on clearing progress for a specific organization' do
       before { user.clear_progress_for!(organization_1) }
@@ -769,6 +775,7 @@ describe User, organization_workspace: :test do
       it { expect(user.assignments.count).to eq 1 }
       it { expect(user.indicators.count).to eq 3 }
       it { expect(user.user_stats.count).to eq 1 }
+      it { expect(messages_count).to eq 2 }
     end
 
     context 'on general progress clear' do
@@ -777,6 +784,7 @@ describe User, organization_workspace: :test do
       it { expect(user.assignments.count).to eq 0 }
       it { expect(user.indicators.count).to eq 0 }
       it { expect(user.user_stats.count).to eq 0 }
+      it { expect(messages_count).to eq 1 }
     end
   end
 end


### PR DESCRIPTION
## :dart: Goal
Ease support tasks that require deleting user progress.

## :memo: Details
Adding `clear_progress_for!` to users to allow clearing progress for a user for a specific organization or optionally, all organizations.

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.