### PR TITLE
Fix messages count on user stats

### DIFF
--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -31,7 +31,7 @@ class UserStats < ApplicationRecord
   private
 
   def messages_in_discussions_count(date_range = nil)
-    date_filter = { date: date_range }.compact
+    date_filter = { created_at: date_range }.compact
     result = Message.joins(:discussion)
         .where({sender: user.uid, discussions: { organization: organization }}.merge(date_filter))
         .group(:approved)

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -33,7 +33,7 @@ class UserStats < ApplicationRecord
   def messages_in_discussions_count(date_range = nil)
     date_filter = { created_at: date_range }.compact
     result = Message.joins(:discussion)
-        .where({sender: user.uid, discussions: { organization: organization }}.merge(date_filter))
+        .where({sender: user.uid, deletion_motive: nil, discussions: { organization: organization }}.merge(date_filter))
         .group(:approved)
         .count
     unapproved = result[false] || 0

--- a/spec/models/user_stats_spec.rb
+++ b/spec/models/user_stats_spec.rb
@@ -92,6 +92,11 @@ describe UserStats, organization_workspace: :test do
       context 'with date filter' do
         it { expect(stats.activity(3.day.until..1.day.until)[:messages]).to eq(count: 1, approved: 0) }
       end
+
+      context 'with deleted message' do
+        before { discussion.messages.last.soft_delete! :self_deleted, user }
+        it { expect(stats.activity[:messages]).to eq(count: 1, approved: 0) }
+      end
     end
   end
 end

--- a/spec/models/user_stats_spec.rb
+++ b/spec/models/user_stats_spec.rb
@@ -82,7 +82,7 @@ describe UserStats, organization_workspace: :test do
       let(:discussion) { problem.discuss! user, title: 'Need help' }
 
       before { discussion.submit_message!({content: 'Same issue here'}, another_user) }
-      before { discussion.submit_message!({content: 'I forgot to say this', date: 2.days.until}, user) }
+      before { discussion.submit_message!({content: 'I forgot to say this', created_at: 2.days.until}, user) }
       before { discussion.submit_message!({content: 'Oh, this is the answer!', approved: true}, user) }
 
       context 'without date filter' do


### PR DESCRIPTION
## :dart: Goal

Properly count messages on UserStats.

## :memo: Details

The `date` field is used on teacher-to-student `Message`s exclusively, but is `nil` on forum messages. Since the query was filtering by `date`, Laboratory's activity view showed `0 messages` on every week as it never found any results.

Also, we now have soft deleted messages, and we shouldn't count those so I added that.

