### PR TITLE
Fixes exam issues

### DIFF
--- a/app/models/concerns/with_pg_lock.rb
+++ b/app/models/concerns/with_pg_lock.rb
@@ -3,7 +3,7 @@ module WithPgLock
   # Lock PG table, reload model and execute callback if
   # criterion is met
   #
-  def with_pg_lock(callback, criterion = { if: proc { true } })
+  def with_pg_lock(callback, criterion = proc { true })
     # Some notes:
     #
     # * nowait is a postgre specific option and may not work with other databases

--- a/app/models/concerns/with_pg_lock.rb
+++ b/app/models/concerns/with_pg_lock.rb
@@ -1,0 +1,19 @@
+module WithPgLock
+  ##
+  # Lock PG table, reload model and execute callback if
+  # criterion is met
+  #
+  def with_pg_lock(callback, criterion)
+    # Some notes:
+    #
+    # * nowait is a postgre specific option and may not work with other databases
+    # * nowait will raise an exception if the lock can not be acquired
+    # * we are using a double check lock pattern to reduce lock acquisition
+    with_lock('for update nowait') do
+      reload
+      callback.call if criterion.call
+    end if criterion.call
+  rescue
+    nil
+  end
+end

--- a/app/models/concerns/with_pg_lock.rb
+++ b/app/models/concerns/with_pg_lock.rb
@@ -3,7 +3,7 @@ module WithPgLock
   # Lock PG table, reload model and execute callback if
   # criterion is met
   #
-  def with_pg_lock(callback, criterion)
+  def with_pg_lock(callback, criterion = { if: proc { true } })
     # Some notes:
     #
     # * nowait is a postgre specific option and may not work with other databases

--- a/app/models/concerns/with_reminders.rb
+++ b/app/models/concerns/with_reminders.rb
@@ -19,7 +19,7 @@ module WithReminders
   end
 
   # Try to send a reminder, by acquiring a database lock for update
-  # the aproppriate record. This object can't be updated as long as
+  # the appropriate record. This object can't be updated as long as
   # the reminder is being sent.
   #
   # This method is aimed to be sent across multiple servers or processed concurrently

--- a/app/models/concerns/with_reminders.rb
+++ b/app/models/concerns/with_reminders.rb
@@ -25,7 +25,7 @@ module WithReminders
   # This method is aimed to be sent across multiple servers or processed concurrently
   # and still not send duplicate mails
   def try_remind_with_lock!
-    with_pg_lock proc { remind! }, if: proc { should_remind? }
+    with_pg_lock proc { remind! }, proc { should_remind? }
   end
 
   private

--- a/app/models/exam_authorization_request.rb
+++ b/app/models/exam_authorization_request.rb
@@ -21,7 +21,7 @@ class ExamAuthorizationRequest < ApplicationRecord
   def icon
     case status.to_sym
     when :pending
-      { class: 'info-circle', type: 'info' }
+      { class: 'hourglass', type: 'info' }
     when :approved
       { class: 'check-circle', type: 'success' }
     when :rejected

--- a/app/models/exam_registration.rb
+++ b/app/models/exam_registration.rb
@@ -49,7 +49,7 @@ class ExamRegistration < ApplicationRecord
   # This method is aimed to be sent across multiple servers or processed concurrently
   # and still not send duplicate mails
   def process_requests!
-    with_pg_lock proc { process_authorization_requests! }, if: proc { !processed? }
+    with_pg_lock proc { process_authorization_requests! }, proc { !processed? }
   end
 
   def process_authorization_requests!

--- a/app/models/exam_registration.rb
+++ b/app/models/exam_registration.rb
@@ -44,7 +44,7 @@ class ExamRegistration < ApplicationRecord
   end
 
   # Try to process authorization request, by acquiring a database lock for update
-  # the aproppriate record.
+  # the appropriate record.
   #
   # This method is aimed to be sent across multiple servers or processed concurrently
   # and still not send duplicate mails

--- a/app/models/exam_registration.rb
+++ b/app/models/exam_registration.rb
@@ -41,10 +41,16 @@ class ExamRegistration < ApplicationRecord
   end
 
   def process_requests!
-    authorization_requests.each do |it|
-      process_request! it
-      it.try_authorize!
-    end
+    authorization_requests.each { |it| process_authorization_request it }
+  end
+
+  def process_authorization_request(authorization_request)
+    with_lock('for update nowait') do
+      process_request! authorization_request
+      authorization_request.try_authorize!
+    end if authorization_request.pending?
+  rescue
+    nil
   end
 
   def authorization_request_for(user)

--- a/db/migrate/20210512200453_add_processed_flag_to_exam_registration.rb
+++ b/db/migrate/20210512200453_add_processed_flag_to_exam_registration.rb
@@ -1,0 +1,5 @@
+class AddProcessedFlagToExamRegistration < ActiveRecord::Migration[5.1]
+  def change
+    add_column :exam_registrations, :processed, :boolean, default: false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210330175706) do
+ActiveRecord::Schema.define(version: 20210512200453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -193,6 +193,7 @@ ActiveRecord::Schema.define(version: 20210330175706) do
     t.bigint "organization_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "processed", default: false
     t.index ["organization_id"], name: "index_exam_registrations_on_organization_id"
   end
 


### PR DESCRIPTION
## :dart: Goal
Add support for process exam registrations by rake task

## :memo: Details
It was necessary to add a flag to indicate whether the exam registration was processed or not. Because of that, a lock had to be implemented to prevent the different instances, if any, process the same update multiple times. That logic was already implemented so it was only extracted to a mixin.

## :warning: Dependencies
none

## :back: Backwards compatibility
100%

## :soon: Future work

