### PR TITLE
Feature moderator take care of

### DIFF
--- a/app/models/concerns/with_responsible_moderator.rb
+++ b/app/models/concerns/with_responsible_moderator.rb
@@ -28,7 +28,7 @@ module WithResponsibleModerator
   end
 
   def can_toggle_responsible?(user)
-    user&.moderator_here? && (no_current_responsible? || responsible?(user))
+    can_have_responsible? && user_can_be_responsible?(user)
   end
 
   private
@@ -39,5 +39,13 @@ module WithResponsibleModerator
 
   def no_responsible!
     update! responsible_moderator_at: nil, responsible_moderator_by: nil
+  end
+
+  def user_can_be_responsible?(user)
+    user&.moderator_here? && (no_current_responsible? || responsible?(user))
+  end
+
+  def can_have_responsible?
+    opened? || pending_review?
   end
 end

--- a/app/models/concerns/with_responsible_moderator.rb
+++ b/app/models/concerns/with_responsible_moderator.rb
@@ -15,6 +15,10 @@ module WithResponsibleModerator
     responsible_moderator_at.present? && (responsible_moderator_at + MODERATOR_MAX_RESPONSIBLE_TIME).future?
   end
 
+  def responsible?(moderator)
+    any_responsible? && responsible_moderator_by == moderator
+  end
+
   def current_responsible_visible_for?(user)
     user&.moderator_here? && any_responsible?
   end

--- a/app/models/concerns/with_responsible_moderator.rb
+++ b/app/models/concerns/with_responsible_moderator.rb
@@ -4,15 +4,19 @@ module WithResponsibleModerator
   MODERATOR_MAX_RESPONSIBLE_TIME = 45.minutes
 
   def toggle_responsible!(moderator)
-    if any_responsible?
+    if responsible?(moderator)
       no_responsible!
-    else
+    elsif no_current_responsible?
       responsible! moderator
     end
   end
 
   def any_responsible?
     responsible_moderator_at.present? && (responsible_moderator_at + MODERATOR_MAX_RESPONSIBLE_TIME).future?
+  end
+
+  def no_current_responsible?
+    !any_responsible?
   end
 
   def responsible?(moderator)

--- a/app/models/concerns/with_responsible_moderator.rb
+++ b/app/models/concerns/with_responsible_moderator.rb
@@ -15,6 +15,10 @@ module WithResponsibleModerator
     responsible_moderator_at.present? && (responsible_moderator_at + MODERATOR_MAX_RESPONSIBLE_TIME).future?
   end
 
+  def current_responsible_visible_for?(user)
+    user&.moderator_here? && any_responsible?
+  end
+
   private
 
   def responsible!(moderator)

--- a/app/models/concerns/with_responsible_moderator.rb
+++ b/app/models/concerns/with_responsible_moderator.rb
@@ -1,0 +1,25 @@
+module WithResponsibleModerator
+  extend ActiveSupport::Concern
+
+  def toggle_responsible!(moderator)
+    if any_responsible?
+      no_responsible!
+    else
+      responsible! moderator
+    end
+  end
+
+  def any_responsible?
+    responsible_moderator_at.present?
+  end
+
+  private
+
+  def responsible!(moderator)
+    update! responsible_moderator_at: Time.now, responsible_moderator_by: moderator
+  end
+
+  def no_responsible!
+    update! responsible_moderator_at: nil, responsible_moderator_by: nil
+  end
+end

--- a/app/models/concerns/with_responsible_moderator.rb
+++ b/app/models/concerns/with_responsible_moderator.rb
@@ -27,6 +27,10 @@ module WithResponsibleModerator
     user&.moderator_here? && any_responsible?
   end
 
+  def can_toggle_responsible?(user)
+    user&.moderator_here? && (no_current_responsible? || responsible?(user))
+  end
+
   private
 
   def responsible!(moderator)

--- a/app/models/concerns/with_responsible_moderator.rb
+++ b/app/models/concerns/with_responsible_moderator.rb
@@ -1,6 +1,8 @@
 module WithResponsibleModerator
   extend ActiveSupport::Concern
 
+  MODERATOR_MAX_RESPONSIBLE_TIME = 45.minutes
+
   def toggle_responsible!(moderator)
     if any_responsible?
       no_responsible!
@@ -10,7 +12,7 @@ module WithResponsibleModerator
   end
 
   def any_responsible?
-    responsible_moderator_at.present?
+    responsible_moderator_at.present? && (responsible_moderator_at + MODERATOR_MAX_RESPONSIBLE_TIME).future?
   end
 
   private

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -124,6 +124,8 @@ class Discussion < ApplicationRecord
       update! status: status,
               status_updated_by: user,
               status_updated_at: Time.now
+
+      no_responsible! if responsible?(user)
     end
   end
 

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -1,5 +1,5 @@
 class Discussion < ApplicationRecord
-  include WithDiscussionStatus, WithScopedQueries, Contextualization
+  include WithDiscussionStatus, WithScopedQueries, Contextualization, WithResponsibleModerator
 
   belongs_to :item, polymorphic: true
   has_many :messages, -> { order(:created_at) }, dependent: :destroy

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -163,25 +163,6 @@ class Discussion < ApplicationRecord
             requires_moderator_response: !has_moderator_response
   end
 
-  def update_last_moderator_access!(user)
-    if user&.moderator_here? && !last_moderator_access_visible_for?(user)
-      update! last_moderator_access_at: Time.now,
-              last_moderator_access_by: user
-    end
-  end
-
-  def being_accessed_by_moderator?
-    last_moderator_access_at.present? && (last_moderator_access_at + MODERATOR_REVIEW_AVERAGE_TIME).future?
-  end
-
-  def last_moderator_access_visible_for?(user)
-    show_last_moderator_access_for?(user) && being_accessed_by_moderator?
-  end
-
-  def show_last_moderator_access_for?(user)
-    user&.moderator_here? && last_moderator_access_by != user
-  end
-
   def self.debatable_for(klazz, params)
     debatable_id = params[:"#{klazz.underscore}_id"]
     klazz.constantize.find(debatable_id)

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -99,6 +99,7 @@ class Discussion < ApplicationRecord
     messages.create(message)
     user.subscribe_to! self
     unread_subscriptions(user)
+    no_responsible! if responsible?(user)
   end
 
   def authorized?(user)

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -28,8 +28,6 @@ class Discussion < ApplicationRecord
   delegate :language, to: :item
   delegate :to_discussion_status, to: :status
 
-  MODERATOR_REVIEW_AVERAGE_TIME = 17.minutes
-
   scope :for_user, -> (user) do
     if user.try(:moderator_here?)
       all

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -5,7 +5,7 @@ class Discussion < ApplicationRecord
   has_many :messages, -> { order(:created_at) }, dependent: :destroy
   belongs_to :initiator, class_name: 'User'
 
-  belongs_to :last_moderator_access_by, class_name: 'User', optional: true
+  belongs_to :responsible_moderator_by, class_name: 'User', optional: true
   belongs_to :status_updated_by, class_name: 'User', optional: true
 
   belongs_to :exercise, foreign_type: :exercise, foreign_key: 'item_id'

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -81,7 +81,7 @@ class Discussion < ApplicationRecord
   end
 
   def friendly
-    initiator.name
+    initiator.abbreviated_name
   end
 
   def subscription_for(user)

--- a/db/migrate/20210518100153_rename_last_moderator_access.rb
+++ b/db/migrate/20210518100153_rename_last_moderator_access.rb
@@ -1,0 +1,6 @@
+class RenameLastModeratorAccess < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :discussions, :last_moderator_access_by_id, :responsible_moderator_by_id
+    rename_column :discussions, :last_moderator_access_at, :responsible_moderator_at
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210512200453) do
+ActiveRecord::Schema.define(version: 20210518100153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -151,8 +151,8 @@ ActiveRecord::Schema.define(version: 20210512200453) do
     t.integer "messages_count", default: 0
     t.integer "validated_messages_count", default: 0
     t.boolean "requires_moderator_response", default: true
-    t.string "last_moderator_access_by_id"
-    t.datetime "last_moderator_access_at"
+    t.string "responsible_moderator_by_id"
+    t.datetime "responsible_moderator_at"
     t.bigint "status_updated_by_id"
     t.datetime "status_updated_at"
     t.index ["initiator_id"], name: "index_discussions_on_initiator_id"

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -193,59 +193,6 @@ describe Discussion, organization_workspace: :test do
     end
   end
 
-  describe '#update_last_moderator_access!' do
-    let(:discussion) { create(:discussion, organization: Organization.current) }
-    before { discussion.update_last_moderator_access! accessor }
-
-    context 'when user is moderator' do
-      let(:accessor) { create(:user, permissions: {moderator: 'test/*'}) }
-
-      it { expect(discussion.last_moderator_access_by).to eq accessor }
-      it { expect(discussion.last_moderator_access_at).to_not be nil }
-
-      it { expect(discussion.being_accessed_by_moderator?).to be true }
-      it { expect(discussion.last_moderator_access_visible_for? accessor).to be false }
-      it { expect(discussion.show_last_moderator_access_for? accessor).to be false }
-
-      context 'when accessed again right after' do
-        before { discussion.update_last_moderator_access! next_accessor }
-
-        context 'when next accessor is moderator' do
-          let(:next_accessor) { create(:user, permissions: {moderator: 'test/*'}) }
-
-          it { expect(discussion.last_moderator_access_by).to eq accessor }
-          it { expect(discussion.last_moderator_access_at).to_not be nil }
-
-          it { expect(discussion.being_accessed_by_moderator?).to be true }
-          it { expect(discussion.last_moderator_access_visible_for? next_accessor).to be true }
-          it { expect(discussion.show_last_moderator_access_for? next_accessor).to be true }
-        end
-
-        context 'when next accessor is student' do
-          let(:next_accessor) { create(:user, permissions: {student: 'test/*'}) }
-
-          it { expect(discussion.last_moderator_access_by).to eq accessor }
-          it { expect(discussion.last_moderator_access_at).to_not be nil }
-
-          it { expect(discussion.being_accessed_by_moderator?).to be true }
-          it { expect(discussion.last_moderator_access_visible_for? next_accessor).to be false }
-          it { expect(discussion.show_last_moderator_access_for? next_accessor).to be false }
-        end
-      end
-    end
-
-    context 'when user is student' do
-      let(:accessor) { create(:user, permissions: {student: 'test/*'}) }
-
-      it { expect(discussion.last_moderator_access_by).to be nil }
-      it { expect(discussion.last_moderator_access_at).to be nil }
-
-      it { expect(discussion.being_accessed_by_moderator?).to be false }
-      it { expect(discussion.last_moderator_access_visible_for? accessor).to be false }
-      it { expect(discussion.show_last_moderator_access_for? accessor).to be false }
-    end
-  end
-
   describe '#toggle_upvote!' do
     let(:discussion) { create(:discussion, {organization: Organization.current}) }
 

--- a/spec/models/with_responsible_moderator_spec.rb
+++ b/spec/models/with_responsible_moderator_spec.rb
@@ -1,0 +1,148 @@
+require 'spec_helper'
+
+describe WithResponsibleModerator, organization_workspace: :test do
+  let(:student) { create(:user, permissions: {student: 'test/*'}) }
+  let(:discussion) { create(:exercise).discuss! student, title: 'Need help' }
+  let(:moderator) { create(:user, permissions: {student: 'test/*', moderator: 'test/*'}) }
+  let(:another_moderator) { create(:user, permissions: {student: 'test/*', moderator: 'test/*'}) }
+
+  describe '#toggle_responsible!' do
+    context 'when no one is responsible' do
+      before { discussion.toggle_responsible! moderator }
+
+      it { expect(discussion.any_responsible?).to be true }
+      it { expect(discussion.responsible? moderator).to be true }
+    end
+
+    context 'when moderator is already responsible' do
+      before do
+        discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.now
+        discussion.toggle_responsible! moderator
+      end
+
+      it { expect(discussion.any_responsible?).to be false }
+      it { expect(discussion.responsible? moderator).to be false }
+    end
+
+    context 'when another moderator is already responsible' do
+      before do
+        discussion.update! responsible_moderator_by: another_moderator, responsible_moderator_at: Time.now
+        discussion.toggle_responsible! moderator
+      end
+
+      it { expect(discussion.any_responsible?).to be true }
+      it { expect(discussion.responsible? moderator).to be false }
+    end
+
+    describe '#any_responsible?' do
+      context 'when a discussion is new' do
+        it { expect(discussion.any_responsible?).to be false }
+      end
+
+      context 'when a moderator is responsible' do
+        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.now }
+
+        it { expect(discussion.any_responsible?).to be true }
+      end
+
+      context 'when a moderator was responsible but too much time passed' do
+        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.now - 1.hour }
+
+        it { expect(discussion.any_responsible?).to be false }
+      end
+    end
+
+    describe '#responsible?' do
+      context 'when discussion has no responsible' do
+        it { expect(discussion.responsible? moderator).to be false }
+      end
+
+      context 'when a moderator is responsible' do
+        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.now }
+
+        it { expect(discussion.responsible? moderator).to be true }
+      end
+
+      context 'when another moderator is responsible' do
+        before { discussion.update! responsible_moderator_by: another_moderator, responsible_moderator_at: Time.now }
+
+        it { expect(discussion.responsible? moderator).to be false }
+      end
+
+      context 'when a moderator was responsible but too much time passed' do
+        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.now - 1.hour }
+
+        it { expect(discussion.responsible? moderator).to be false }
+      end
+    end
+
+    describe '#current_responsible_visible_for?' do
+      context 'when there is a responsible' do
+        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.now }
+
+        context 'when user is a student' do
+          it { expect(discussion.current_responsible_visible_for? student).to be false }
+        end
+
+        context 'when user is a moderator' do
+          it { expect(discussion.current_responsible_visible_for? moderator).to be true }
+        end
+      end
+
+      context 'when there is no responsible' do
+        context 'when user is a student' do
+          it { expect(discussion.current_responsible_visible_for? student).to be false }
+        end
+
+        context 'when user is a moderator' do
+          it { expect(discussion.current_responsible_visible_for? moderator).to be false }
+        end
+      end
+    end
+
+    describe '#can_toggle_responsible?' do
+      context 'when there is a responsible' do
+        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.now }
+
+        context 'when user is a student' do
+          it { expect(discussion.can_toggle_responsible? student).to be false }
+        end
+
+        context 'when user is the responsible moderator' do
+          it { expect(discussion.can_toggle_responsible? moderator).to be true }
+        end
+
+        context 'when user is another moderator' do
+          it { expect(discussion.can_toggle_responsible? another_moderator).to be false }
+        end
+      end
+
+      context 'when there is no responsible' do
+        context 'when user is a student' do
+          it { expect(discussion.can_toggle_responsible? student).to be false }
+        end
+
+        context 'when user is a moderator' do
+          context 'when discussion is open' do
+            it { expect(discussion.can_toggle_responsible? moderator).to be true }
+          end
+
+          context 'when discussion is pending review' do
+            before { discussion.update! status: Mumuki::Domain::Status::Discussion::PendingReview }
+            it { expect(discussion.can_toggle_responsible? moderator).to be true }
+          end
+
+          context 'when discussion is closed' do
+            before { discussion.update! status: Mumuki::Domain::Status::Discussion::Closed }
+            it { expect(discussion.can_toggle_responsible? moderator).to be false }
+          end
+
+          context 'when discussion is solved' do
+            before { discussion.update! status: Mumuki::Domain::Status::Discussion::Solved }
+            it { expect(discussion.can_toggle_responsible? moderator).to be false }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## :dart: Goal

Lets a moderator take care of a discussion, whether for replying or changing status. Replaces `last_moderator_access`.

## :memo: Details

A moderator can take care of a discussion for 45 minutes or until they post a reply or change its status, whichever occurs first. Only one moderator can take care of a discussion at the same time.

A moderator can take care of a discussion, then, if no one else is responsible and the discussion is pending review or opened, which are the types that usually require attention.

Also, changes `name` for `abbreviated_name` on `friendly`, which we were missing.

## :back: Backwards compatibility

`last_moderator_access` is no longer supported.

