### PR TITLE
Add time_zone to organization profile

### DIFF
--- a/lib/mumuki/domain/factories/organization_factory.rb
+++ b/lib/mumuki/domain/factories/organization_factory.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     locale { 'en' }
     settings {}
     name { 'an-organization' }
+    time_zone { 'UTC' }
     book
   end
 

--- a/lib/mumuki/domain/organization/profile.rb
+++ b/lib/mumuki/domain/organization/profile.rb
@@ -13,7 +13,8 @@ class Mumuki::Domain::Organization::Profile < Mumukit::Platform::Model
                       :community_link,
                       :errors_explanations,
                       :welcome_email_template,
-                      :welcome_email_sender
+                      :welcome_email_sender,
+                      :time_zone
 
   def locale_json
     locale_h.to_json
@@ -38,4 +39,9 @@ class Mumuki::Domain::Organization::Profile < Mumukit::Platform::Model
   def open_graph_image_url
     @open_graph_image_url ||= Mumukit::Platform.laboratory.url_for("logo-alt.png")  # Best image size: 256x256
   end
+
+  def time_zone
+    @time_zone || 'Buenos Aires'
+  end
+
 end

--- a/lib/mumuki/domain/organization/settings.rb
+++ b/lib/mumuki/domain/organization/settings.rb
@@ -46,4 +46,5 @@ class Mumuki::Domain::Organization::Settings < Mumukit::Platform::Model
   def in_preparation?
     in_preparation_until.present? && in_preparation_until.future?
   end
+
 end

--- a/spec/lib/organization_helpers_spec.rb
+++ b/spec/lib/organization_helpers_spec.rb
@@ -37,7 +37,8 @@ describe Mumukit::Platform::Organization do
         description: 'Academy',
         terms_of_service: 'TOS',
         logo_url: 'http://mumuki.io/logo-alt-large.png',
-        locale: 'en'
+        locale: 'en',
+        time_zone: 'Amsterdam'
       },
       theme: {
         theme_stylesheet: '.foo { }',
@@ -157,6 +158,7 @@ describe Mumukit::Platform::Organization do
       it { expect(subject.contact_email).to eq 'issues@mumuki.io' }
       it { expect(subject.description).to eq 'Academy' }
       it { expect(subject.terms_of_service).to eq 'TOS' }
+      it { expect(subject.time_zone).to eq 'Amsterdam' }
 
       it { expect(subject.locale).to eq 'en' }
       it { expect(subject.locale_json).to json_eq facebook_code: 'en_US', auth0_code: 'en', name: 'English' }
@@ -173,6 +175,7 @@ describe Mumukit::Platform::Organization do
       it { expect(subject.favicon_url).to eq '/favicon.ico' }
       it { expect(subject.breadcrumb_image_url).to eq nil }
       it { expect(subject.open_graph_image_url).to eq 'http://localmumuki.io/logo-alt.png' }
+      it { expect(subject.time_zone).to eq 'Buenos Aires' }
     end
 
     describe Mumuki::Domain::Organization::Profile do


### PR DESCRIPTION
## :dart: Goal
Add timezone to organization's profile to improve datetime fields