### PR TITLE
Feature improve discussion requires attention

### DIFF
--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -149,6 +149,10 @@ class Discussion < ApplicationRecord
     validated_messages_count > 0
   end
 
+  def requires_attention_for?(user)
+    user&.moderator_here? && requires_attention?
+  end
+
   def requires_attention?
     no_current_responsible? && (requires_moderator_response? || pending_review?)
   end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -15,14 +15,14 @@ class Discussion < ApplicationRecord
 
   scope :by_language, -> (language) { includes(:exercise).joins(exercise: :language).where(languages: {name: language}) }
   scope :order_by_responses_count, -> (direction) { reorder(validated_messages_count: direction, messages_count: opposite(direction)) }
-  scope :by_requires_moderator_response, -> (boolean) { where(requires_moderator_response: boolean.to_boolean) }
+  scope :by_requires_attention, -> (boolean) { where(requires_moderator_response: boolean.to_boolean) }
 
   after_create :subscribe_initiator!
 
   markdown_on :description
 
   sortable :responses_count, :upvotes_count, :created_at, default: :created_at_desc
-  filterable :status, :language, :requires_moderator_response
+  filterable :status, :language, :requires_attention
   pageable
 
   delegate :language, to: :item

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -149,6 +149,10 @@ class Discussion < ApplicationRecord
     validated_messages_count > 0
   end
 
+  def requires_attention?
+    no_current_responsible? && (requires_moderator_response? || pending_review?)
+  end
+
   def subscribe_initiator!
     initiator.subscribe_to! self
   end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -15,7 +15,9 @@ class Discussion < ApplicationRecord
 
   scope :by_language, -> (language) { includes(:exercise).joins(exercise: :language).where(languages: {name: language}) }
   scope :order_by_responses_count, -> (direction) { reorder(validated_messages_count: direction, messages_count: opposite(direction)) }
-  scope :by_requires_attention, -> (boolean) { where(requires_moderator_response: boolean.to_boolean) }
+  scope :by_requires_attention, -> (boolean) { where(requires_moderator_response: boolean.to_boolean).no_responsible_moderator }
+  scope :no_responsible_moderator, -> { where('responsible_moderator_at < ?', Time.now - MODERATOR_MAX_RESPONSIBLE_TIME)
+                                          .or(where(responsible_moderator_at: nil)) }
 
   after_create :subscribe_initiator!
 

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -15,9 +15,10 @@ class Discussion < ApplicationRecord
 
   scope :by_language, -> (language) { includes(:exercise).joins(exercise: :language).where(languages: {name: language}) }
   scope :order_by_responses_count, -> (direction) { reorder(validated_messages_count: direction, messages_count: opposite(direction)) }
-  scope :by_requires_attention, -> (boolean) { where(requires_moderator_response: boolean.to_boolean).no_responsible_moderator }
+  scope :by_requires_attention, -> (boolean) { where(requires_moderator_response: boolean.to_boolean).or(pending_review).no_responsible_moderator }
   scope :no_responsible_moderator, -> { where('responsible_moderator_at < ?', Time.now - MODERATOR_MAX_RESPONSIBLE_TIME)
                                           .or(where(responsible_moderator_at: nil)) }
+  scope :pending_review, -> { where(status: Mumuki::Domain::Status::Discussion::PendingReview) }
 
   after_create :subscribe_initiator!
 

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -15,7 +15,8 @@ class Discussion < ApplicationRecord
 
   scope :by_language, -> (language) { includes(:exercise).joins(exercise: :language).where(languages: {name: language}) }
   scope :order_by_responses_count, -> (direction) { reorder(validated_messages_count: direction, messages_count: opposite(direction)) }
-  scope :by_requires_attention, -> (boolean) { where(requires_moderator_response: boolean.to_boolean).or(pending_review).no_responsible_moderator }
+  scope :by_requires_attention, -> (boolean) { requires_moderator_response(boolean).or(pending_review).no_responsible_moderator }
+  scope :requires_moderator_response, -> (boolean) { where(requires_moderator_response: boolean.to_boolean) }
   scope :no_responsible_moderator, -> { where('responsible_moderator_at < ?', Time.now - MODERATOR_MAX_RESPONSIBLE_TIME)
                                           .or(where(responsible_moderator_at: nil)) }
   scope :pending_review, -> { where(status: Mumuki::Domain::Status::Discussion::PendingReview) }

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -17,10 +17,10 @@ class Discussion < ApplicationRecord
   scope :order_by_responses_count, -> (direction) { reorder(validated_messages_count: direction, messages_count: opposite(direction)) }
   scope :by_requires_attention, -> (boolean) { opened_and_requires_moderator_response(boolean).or(pending_review).no_responsible_moderator }
   scope :opened_and_requires_moderator_response, -> (boolean) { where(requires_moderator_response: boolean.to_boolean)
-                                                                  .where(status: Mumuki::Domain::Status::Discussion::Opened) }
+                                                                  .where(status: :opened) }
   scope :no_responsible_moderator, -> { where('responsible_moderator_at < ?', Time.now - MODERATOR_MAX_RESPONSIBLE_TIME)
                                           .or(where(responsible_moderator_at: nil)) }
-  scope :pending_review, -> { where(status: Mumuki::Domain::Status::Discussion::PendingReview) }
+  scope :pending_review, -> { where(status: :pending_review) }
 
   after_create :subscribe_initiator!
 

--- a/lib/mumuki/domain/status/discussion/closed.rb
+++ b/lib/mumuki/domain/status/discussion/closed.rb
@@ -12,4 +12,8 @@ module Mumuki::Domain::Status::Discussion::Closed
   def self.iconize
     {class: :danger, type: 'times-circle'}
   end
+
+  def self.requires_attention_for?(_)
+    false
+  end
 end

--- a/lib/mumuki/domain/status/discussion/opened.rb
+++ b/lib/mumuki/domain/status/discussion/opened.rb
@@ -28,4 +28,8 @@ module Mumuki::Domain::Status::Discussion::Opened
   def self.should_be_shown?(*)
     true
   end
+
+  def self.requires_attention_for?(discussion)
+    discussion.requires_moderator_response?
+  end
 end

--- a/lib/mumuki/domain/status/discussion/pending_review.rb
+++ b/lib/mumuki/domain/status/discussion/pending_review.rb
@@ -12,4 +12,8 @@ module Mumuki::Domain::Status::Discussion::PendingReview
   def self.iconize
     {class: :info, type: 'hourglass'}
   end
+
+  def self.requires_attention_for?(_)
+    true
+  end
 end

--- a/lib/mumuki/domain/status/discussion/solved.rb
+++ b/lib/mumuki/domain/status/discussion/solved.rb
@@ -16,4 +16,8 @@ module Mumuki::Domain::Status::Discussion::Solved
   def self.should_be_shown?(*)
     true
   end
+
+  def self.requires_attention_for?(_)
+    false
+  end
 end

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -330,6 +330,11 @@ describe Discussion, organization_workspace: :test do
         it { expect(Discussion.by_requires_attention(true)).to match_array [discussion_pending_review] }
       end
     end
+
+    context '#requires_attention_for' do
+      it { expect(discussion_opened.requires_attention_for? user).to be false }
+      it { expect(discussion_opened.requires_attention_for? moderator).to be true }
+    end
   end
 
 


### PR DESCRIPTION
## :dart: Goal

Improve the logic for deciding if a discussion requires attention. 

## :memo: Details

Currently, the criteria for a discussion requiring attention is as follows:
* Is the last message on the discussion validated? That is, was it either posted by a student and approved by a moderator, or posted by a moderator?
* Alternatively, are there no messages yet?

...that's it, and it falls short on many cases.

Even though we were calling it `Requires attention` on the UI, the logic behind it was just using `requires_moderator_response`, which is not suited for every case. After talking with the moderator team, a discussion will now require attention if:
* It's pending review, no matter who wrote the last message. Discussions pending review always require an action, as they should be closed or solved by the moderators.
* It's opened and the last message on the discussion is not validated. This is the case that retains the current logic.
* In both cases, a moderator must not be responsible at the time.

Once a moderator [decides to take care of a discussion](https://github.com/mumuki/mumuki-domain/pull/218), it doesn't require attention anymore - someone is already working on it. Therefore, a moderator applying the `Requires attention` filter will only see discussions that they can work on.

On the other hand, closed and solved discussions will now never require attention.

## :soon: Future work

`requires_attention_for?` is not used right now, but will be very soon as I intend to add a visual indicator for that on the discussions view.
