### PR TITLE
Chore misc time zone fixes

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -152,7 +152,7 @@ class ApplicationRecord < ActiveRecord::Base
   def self.active_between(start_date_field, end_date_field, **options)
     define_singleton_method(:active) do |actually_filter=true|
       if actually_filter
-        self.where("(#{start_date_field} IS NULL OR #{start_date_field} < :now) AND (#{end_date_field} IS NULL OR #{end_date_field} > :now)", now: Time.now)
+        self.where("(#{start_date_field} IS NULL OR #{start_date_field} < :now) AND (#{end_date_field} IS NULL OR #{end_date_field} > :now)", now: Time.current)
       else
         all
       end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -85,7 +85,7 @@ class Assignment < Progress
   def persist_submission!(submission)
     transaction do
       update! submission_id: submission.id
-      update! submitted_at: DateTime.current
+      update! submitted_at: Time.current
       update_submissions_count!
       update_last_submission!
     end
@@ -281,6 +281,6 @@ class Assignment < Progress
   end
 
   def update_last_submission!
-    submitter.update!(last_submission_date: DateTime.current, last_exercise: exercise)
+    submitter.update!(last_submission_date: Time.current, last_exercise: exercise)
   end
 end

--- a/app/models/concerns/with_messages.rb
+++ b/app/models/concerns/with_messages.rb
@@ -9,7 +9,7 @@ module WithMessages
   end
 
   def build_message(body)
-    messages.build({date: DateTime.current, submission_id: submission_id}.merge(body))
+    messages.build({date: Time.current, submission_id: submission_id}.merge(body))
   end
 
   def has_messages?

--- a/app/models/concerns/with_reminders.rb
+++ b/app/models/concerns/with_reminders.rb
@@ -11,7 +11,7 @@ module WithReminders
 
   def remind!
     build_reminder.deliver_now
-    update! last_reminded_date: Time.now
+    update! last_reminded_date: Time.current
   end
 
   def should_remind?

--- a/app/models/concerns/with_responsible_moderator.rb
+++ b/app/models/concerns/with_responsible_moderator.rb
@@ -34,7 +34,7 @@ module WithResponsibleModerator
   private
 
   def responsible!(moderator)
-    update! responsible_moderator_at: Time.now, responsible_moderator_by: moderator
+    update! responsible_moderator_at: Time.current, responsible_moderator_by: moderator
   end
 
   def no_responsible!

--- a/app/models/concerns/with_soft_deletion.rb
+++ b/app/models/concerns/with_soft_deletion.rb
@@ -7,7 +7,7 @@ module WithSoftDeletion
   end
 
   def soft_delete!(motive, deleter)
-    update! deletion_motive: motive, deleted_by: deleter, deleted_at: Time.now
+    update! deletion_motive: motive, deleted_by: deleter, deleted_at: Time.current
   end
 
   def deleted?

--- a/app/models/concerns/with_terms_acceptance.rb
+++ b/app/models/concerns/with_terms_acceptance.rb
@@ -58,8 +58,7 @@ module WithTermsAcceptance
   end
 
   def accept_terms!(terms)
-    update! unaccepted_terms_scopes_in(terms).to_h { |scope| [term_acceptance_field_for(scope), Time.now] }
+    update! unaccepted_terms_scopes_in(terms).to_h { |scope| [term_acceptance_field_for(scope), Time.current] }
   end
 
 end
-

--- a/app/models/concerns/with_timed_enablement.rb
+++ b/app/models/concerns/with_timed_enablement.rb
@@ -2,7 +2,7 @@ module WithTimedEnablement
   extend ActiveSupport::Concern
 
   def enabled?
-    enabled_range.cover? DateTime.current
+    enabled_range.cover? Time.current
   end
 
   def enabled_range

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -14,7 +14,7 @@ class Course < ApplicationRecord
   resource_fields :slug, :shifts, :code, :days, :period, :description, :period_start, :period_end
 
   def current_invitation
-    invitations.where('expiration_date > ?', Time.now).first
+    invitations.where('expiration_date > ?', Time.current).first
   end
 
   def import_from_resource_h!(resource_h)
@@ -49,7 +49,7 @@ class Course < ApplicationRecord
     period =~ /^(\d{4})?/
     year = $1.to_i
 
-    return nil unless year.between? 2014, (DateTime.now.year + 1)
+    return nil unless year.between? 2014, (DateTime.current.year + 1)
 
     self.period_start = DateTime.new(year).beginning_of_year
     self.period_end = DateTime.new(year).end_of_year

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -49,7 +49,7 @@ class Course < ApplicationRecord
     period =~ /^(\d{4})?/
     year = $1.to_i
 
-    return nil unless year.between? 2014, (DateTime.current.year + 1)
+    return nil unless year.between? 2014, (Time.current.year + 1)
 
     self.period_start = DateTime.new(year).beginning_of_year
     self.period_end = DateTime.new(year).end_of_year

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -54,7 +54,7 @@ class Discussion < ApplicationRecord
   def navigable_content_in(_)
     nil
   end
-  
+
   def target
     self
   end
@@ -128,7 +128,7 @@ class Discussion < ApplicationRecord
     if reachable_status_for?(user, status)
       update! status: status,
               status_updated_by: user,
-              status_updated_at: Time.now
+              status_updated_at: Time.current
 
       no_responsible! if responsible?(user)
     end

--- a/app/models/exam.rb
+++ b/app/models/exam.rb
@@ -179,8 +179,8 @@ class Exam < ApplicationRecord
     exam[:organization_id] = Organization.current.id
     exam[:course_id] = Course.locate!(exam[:course].to_s).id
     exam[:users] = User.where(uid: exam[:uids])
-    exam[:start_time] = exam[:start_time].to_time
-    exam[:end_time] = exam[:end_time].to_time
+    exam[:start_time] = exam[:start_time].in_time_zone
+    exam[:end_time] = exam[:end_time].in_time_zone
     exam[:classroom_id] = exam[:eid] if exam[:eid].present?
   end
 

--- a/app/models/exam.rb
+++ b/app/models/exam.rb
@@ -32,7 +32,7 @@ class Exam < ApplicationRecord
   end
 
   def enabled_for?(user)
-    enabled_range_for(user).cover? DateTime.current
+    enabled_range_for(user).cover? Time.current
   end
 
   def in_progress_for?(user)

--- a/app/models/exam_authorization.rb
+++ b/app/models/exam_authorization.rb
@@ -4,7 +4,7 @@ class ExamAuthorization < ApplicationRecord
   belongs_to :exam
 
   def start!
-    update!(started: true, started_at: Time.now) unless started?
+    update!(started: true, started_at: Time.current) unless started?
   end
 
 end

--- a/app/models/exam_registration.rb
+++ b/app/models/exam_registration.rb
@@ -17,7 +17,7 @@ class ExamRegistration < ApplicationRecord
 
   alias_attribute :name, :description
 
-  scope :should_process, -> { where(processed: false).where(arel_table[:end_time].lt(Time.now)) }
+  scope :should_process, -> { where(processed: false).where(arel_table[:end_time].lt(Time.current)) }
 
   def authorization_criterion
     @authorization_criterion ||= ExamRegistration::AuthorizationCriterion.parse(authorization_criterion_type, authorization_criterion_value)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -130,7 +130,7 @@ class Message < ApplicationRecord
   private
 
   def approve!(user)
-    update! approved: true, approved_at: Time.now, approved_by: user
+    update! approved: true, approved_at: Time.current, approved_by: user
   end
 
   def disapprove!

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -23,7 +23,7 @@ class Organization < ApplicationRecord
 
   has_many :certificate_programs
 
-  validates_presence_of :contact_email, :locale
+  validates_presence_of :contact_email, :locale, :time_zone
   validates_presence_of :welcome_email_template, if: :greet_new_users?
   validates :name, uniqueness: true,
                    presence: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -251,7 +251,7 @@ class User < ApplicationRecord
 
   def age
     if birthdate.present?
-      @age ||= Time.now.round_years_since(birthdate.to_time)
+      @age ||= Time.current.round_years_since(birthdate.in_time_zone)
     end
   end
 

--- a/lib/mumuki/domain/organization/profile.rb
+++ b/lib/mumuki/domain/organization/profile.rb
@@ -41,7 +41,7 @@ class Mumuki::Domain::Organization::Profile < Mumukit::Platform::Model
   end
 
   def time_zone
-    @time_zone || 'Buenos Aires'
+    @time_zone
   end
 
 end

--- a/lib/mumuki/domain/organization/settings.rb
+++ b/lib/mumuki/domain/organization/settings.rb
@@ -32,11 +32,11 @@ class Mumuki::Domain::Organization::Settings < Mumukit::Platform::Model
   end
 
   def disabled_from=(disabled_from)
-    @disabled_from = disabled_from&.to_time
+    @disabled_from = disabled_from&.in_time_zone
   end
 
   def in_preparation_until=(in_preparation_until)
-    @in_preparation_until = in_preparation_until&.to_time
+    @in_preparation_until = in_preparation_until&.in_time_zone
   end
 
   def disabled?

--- a/spec/lib/organization_helpers_spec.rb
+++ b/spec/lib/organization_helpers_spec.rb
@@ -173,9 +173,9 @@ describe Mumukit::Platform::Organization do
       it { expect(subject.logo_url).to eq 'https://mumuki.io/logo-alt-large.png' }
       it { expect(subject.banner_url).to eq 'https://mumuki.io/logo-alt-large.png' }
       it { expect(subject.favicon_url).to eq '/favicon.ico' }
-      it { expect(subject.breadcrumb_image_url).to eq nil }
+      it { expect(subject.breadcrumb_image_url).to be nil }
       it { expect(subject.open_graph_image_url).to eq 'http://localmumuki.io/logo-alt.png' }
-      it { expect(subject.time_zone).to eq 'Buenos Aires' }
+      it { expect(subject.time_zone).to be nil }
     end
 
     describe Mumuki::Domain::Organization::Profile do

--- a/spec/models/certificate_program_spec.rb
+++ b/spec/models/certificate_program_spec.rb
@@ -12,56 +12,55 @@ describe CertificateProgram, organization_workspace: :test do
     end
 
     context 'with end_date in the future and no start_date' do
-      let(:certificate_program_end_date) { Time.now + 5.minutes }
+      let(:certificate_program_end_date) { 5.minutes.since }
 
       it { expect(CertificateProgram.ongoing.count).to eq 1 }
     end
 
     context 'with end_date in the past and no start_date' do
-      let(:certificate_program_end_date) { Time.now - 5.minutes }
+      let(:certificate_program_end_date) { 5.minutes.ago }
 
       it { expect(CertificateProgram.ongoing.count).to eq 0 }
     end
 
     context 'with start_date in the past and no end_date' do
-      let(:certificate_program_start_date) { Time.now - 5.minutes }
+      let(:certificate_program_start_date) { 5.minutes.ago }
 
       it { expect(CertificateProgram.ongoing.count).to eq 1 }
     end
 
     context 'with start_date in the future and no end_date' do
-      let(:certificate_program_start_date) { Time.now + 5.minutes }
+      let(:certificate_program_start_date) { 5.minutes.since }
 
       it { expect(CertificateProgram.ongoing.count).to eq 0 }
     end
 
     context 'with end_date in the future and start_date in the past' do
-      let(:certificate_program_end_date) { Time.now + 5.minutes }
-      let(:certificate_program_start_date) { Time.now - 5.minutes }
+      let(:certificate_program_end_date) { 5.minutes.since }
+      let(:certificate_program_start_date) { 5.minutes.ago }
 
       it { expect(CertificateProgram.ongoing.count).to eq 1 }
     end
 
     context 'with both end_date and start_date in the future' do
-      let(:certificate_program_end_date) { Time.now + 5.minutes }
-      let(:certificate_program_start_date) { Time.now + 5.minutes }
+      let(:certificate_program_end_date) { 5.minutes.since }
+      let(:certificate_program_start_date) { 5.minutes.since }
 
       it { expect(CertificateProgram.ongoing.count).to eq 0 }
     end
 
     context 'with both end_date and start_date in the past' do
-      let(:certificate_program_end_date) { Time.now - 5.minutes }
-      let(:certificate_program_start_date) { Time.now - 5.minutes }
+      let(:certificate_program_end_date) { 5.minutes.ago }
+      let(:certificate_program_start_date) { 5.minutes.ago }
 
       it { expect(CertificateProgram.ongoing.count).to eq 0 }
     end
 
     context 'with actually_filter disabled' do
-      let(:certificate_program_end_date) { Time.now - 5.minutes }
-      let(:certificate_program_start_date) { Time.now - 5.minutes }
+      let(:certificate_program_end_date) { 5.minutes.ago }
+      let(:certificate_program_start_date) { 5.minutes.ago }
 
       it { expect(CertificateProgram.ongoing(false).count).to eq 1 }
     end
   end
 end
-

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -7,11 +7,17 @@ describe Organization, organization_workspace: :test do
 
   describe '.import_from_resource_h!' do
     let(:book) { create(:book) }
-    let(:resource_h) { {
-      name: 'zulema',
-      book: book.slug,
-      profile: { locale: 'es', contact_email: 'contact@email.com' }
-    } }
+    let(:resource_h) {
+      {
+        name: 'zulema',
+        book: book.slug,
+        profile: {
+          locale: 'es',
+          time_zone: 'Santiago',
+          contact_email: 'contact@email.com'
+        }
+      }
+    }
     let!(:imported) { Organization.import_from_resource_h! resource_h }
     let(:found) { Organization.find_by(name: 'zulema').to_resource_h }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -712,7 +712,7 @@ describe User, organization_workspace: :test do
 
       it { expect(user.delete_account_token).to be_an_instance_of(String) }
       it { expect(user.delete_account_token).to have_attributes(size: be > 10) }
-      it { expect(user.delete_account_token_expiration_date).to be_between(Time.now, 2.hours.since) }
+      it { expect(user.delete_account_token_expiration_date).to be_between(Time.current, 2.hours.since) }
     end
 
     describe '#delete_account_token_matches?' do

--- a/spec/models/with_responsible_moderator_spec.rb
+++ b/spec/models/with_responsible_moderator_spec.rb
@@ -16,7 +16,7 @@ describe WithResponsibleModerator, organization_workspace: :test do
 
     context 'when moderator is already responsible' do
       before do
-        discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.now
+        discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.current
         discussion.toggle_responsible! moderator
       end
 
@@ -26,7 +26,7 @@ describe WithResponsibleModerator, organization_workspace: :test do
 
     context 'when another moderator is already responsible' do
       before do
-        discussion.update! responsible_moderator_by: another_moderator, responsible_moderator_at: Time.now
+        discussion.update! responsible_moderator_by: another_moderator, responsible_moderator_at: Time.current
         discussion.toggle_responsible! moderator
       end
 
@@ -40,13 +40,13 @@ describe WithResponsibleModerator, organization_workspace: :test do
       end
 
       context 'when a moderator is responsible' do
-        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.now }
+        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.current }
 
         it { expect(discussion.any_responsible?).to be true }
       end
 
       context 'when a moderator was responsible but too much time passed' do
-        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.now - 1.hour }
+        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.current - 1.hour }
 
         it { expect(discussion.any_responsible?).to be false }
       end
@@ -58,19 +58,19 @@ describe WithResponsibleModerator, organization_workspace: :test do
       end
 
       context 'when a moderator is responsible' do
-        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.now }
+        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.current }
 
         it { expect(discussion.responsible? moderator).to be true }
       end
 
       context 'when another moderator is responsible' do
-        before { discussion.update! responsible_moderator_by: another_moderator, responsible_moderator_at: Time.now }
+        before { discussion.update! responsible_moderator_by: another_moderator, responsible_moderator_at: Time.current }
 
         it { expect(discussion.responsible? moderator).to be false }
       end
 
       context 'when a moderator was responsible but too much time passed' do
-        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.now - 1.hour }
+        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.current - 1.hour }
 
         it { expect(discussion.responsible? moderator).to be false }
       end
@@ -78,7 +78,7 @@ describe WithResponsibleModerator, organization_workspace: :test do
 
     describe '#current_responsible_visible_for?' do
       context 'when there is a responsible' do
-        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.now }
+        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.current }
 
         context 'when user is a student' do
           it { expect(discussion.current_responsible_visible_for? student).to be false }
@@ -102,7 +102,7 @@ describe WithResponsibleModerator, organization_workspace: :test do
 
     describe '#can_toggle_responsible?' do
       context 'when there is a responsible' do
-        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.now }
+        before { discussion.update! responsible_moderator_by: moderator, responsible_moderator_at: Time.current }
 
         context 'when user is a student' do
           it { expect(discussion.can_toggle_responsible? student).to be false }


### PR DESCRIPTION
# :dart: Goal

To normalize the way we use dates, times and time zones in the code. 

# :memo: Details

We have reviewed time-zone related code with @fedescarpa 


To sum up: 

* Prefer `.current` over `.now`, in order to properly deal with current `Time.zone` 
* Prefer `Time` over `DateTime` just for consistency
* Prefer  `in_time_zone` over `to_time` and `to_datetime` for the same reasons as item 1

# :warning: Dependencies

Depends on #226 

# :back: Backwards compatibility

This PR should be 100% backwards compatible. 

# :eyes: See also 

* https://thoughtbot.com/blog/its-about-time-zones
* http://winstonyw.com/2014/03/03/time_now_vs_time_zone_now/
* https://jcxia.com/blog/A-DateTime-bug
* https://gist.github.com/pixeltrix/e2298822dd89d854444b