### PR TITLE
Use updated_at instead of submitted_at on activity date filters

### DIFF
--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -11,7 +11,7 @@ class UserStats < ApplicationRecord
   end
 
   def activity(date_range = nil)
-    date_filter = { submitted_at: date_range }.compact
+    date_filter = { updated_at: date_range }.compact
     {
         exercises: {
             solved_count: organization_exercises

--- a/spec/models/user_stats_spec.rb
+++ b/spec/models/user_stats_spec.rb
@@ -27,7 +27,7 @@ describe UserStats, organization_workspace: :test do
         exercises[0].submit_solution!(user, content: '').failed!
 
         assignment = exercises[1].submit_solution!(user, content: '')
-        assignment.update!(submitted_at: 2.days.until, status: 'skipped')
+        assignment.update!(updated_at: 2.days.until, status: 'skipped')
 
         exercises[0].submit_solution!(another_user, content: '').passed!
       end


### PR DESCRIPTION
## :dart: Goal

Use a more reliable field for showing weekly activity stats.

## :memo: Details

We recently noticed a bunch of exercises do not have `submitted_at` and therefore can't be filtered by date. Using `updated_at` is not ideal, as there are a few cases which update an Assignment but do not correspond with a submission, but it will do until @flbulgarelli fixes or helps us fix that bug.

## :soon: Future work

This PR should be reverted around three months after when the aforementioned bug is fixed. Twelve weeks is the maximum time we show filters for.
