### PR TITLE
Feature introduce stale message

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -7,11 +7,7 @@ class Assignment < Progress
 
   belongs_to :exercise
   has_one :guide, through: :exercise
-  has_many :messages,
-           -> { where.not(submission_id: nil).order(date: :desc) },
-           foreign_key: :submission_id,
-           primary_key: :submission_id,
-           dependent: :destroy
+  has_many :messages, -> { order(date: :desc) }, dependent: :destroy
 
   belongs_to :organization
   belongs_to :submitter, class_name: 'User'

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -84,7 +84,6 @@ class Assignment < Progress
 
   def persist_submission!(submission)
     transaction do
-      messages.destroy_all if submission_id.present?
       update! submission_id: submission.id
       update! submitted_at: DateTime.current
       update_submissions_count!

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -24,13 +24,13 @@ class Assignment < Progress
   alias_attribute :status, :submission_status
   alias_attribute :attempts_count, :attemps_count
 
-  scope :by_exercise_ids, -> (exercise_ids) {
+  scope :by_exercise_ids, -> (exercise_ids) do
     where(exercise_id: exercise_ids) if exercise_ids
-  }
+  end
 
-  scope :by_usernames, -> (usernames) {
+  scope :by_usernames, -> (usernames) do
     joins(:submitter).where('users.name' => usernames) if usernames
-  }
+  end
 
   defaults do
     self.query_results = []

--- a/app/models/concerns/with_messages.rb
+++ b/app/models/concerns/with_messages.rb
@@ -9,7 +9,7 @@ module WithMessages
   end
 
   def build_message(body)
-    messages.build({date: DateTime.current}.merge(body))
+    messages.build({date: DateTime.current, submission_id: submission_id}.merge(body))
   end
 
   def has_messages?

--- a/app/models/concerns/with_notifications.rb
+++ b/app/models/concerns/with_notifications.rb
@@ -7,8 +7,7 @@ module WithNotifications
 
   def unread_notifications
     # TODO: message and discussion should trigger a notification instead of being one
-    # include message notifications once they are properly implemented
-    all = notifications.where(read: false) + unread_discussions
+    all = notifications.where(read: false) + unread_messages + unread_discussions
     all.sort_by(&:created_at).reverse
   end
 

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -42,7 +42,7 @@ class Discussion < ApplicationRecord
   end
 
   def visible_messages
-    messages.where.not(deletion_motive: :self_deleted).or(messages.where(deletion_motive: nil))
+    messages.visible
   end
 
   def try_solve!

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -168,14 +168,6 @@ class Exercise < ApplicationRecord
     Exercise.find(id)
   end
 
-  def messages_path_for(user)
-    "api/guides/#{guide.slug}/#{bibliotheca_id}/student/#{URI.escape user.uid}/messages?language=#{language}"
-  end
-
-  def messages_url_for(user)
-    Mumukit::Platform.classroom_api.organic_url_for(Organization.current, messages_path_for(user))
-  end
-
   def description_context
     splitted_description.first.markdownified
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -8,18 +8,18 @@ class Message < ApplicationRecord
   has_one :exercise, through: :assignment
 
   validates_presence_of :content, :sender
-  validate :contextualized?
+  validate :ensure_contextualized
 
   after_save :update_counters_cache!
 
   markdown_on :content
 
   # Visible messages are those that can be publicly seen
-  # in forums. non-direct messages are naver visible.
+  # in forums. non-direct messages are never visible.
   scope :visible, -> () do
     where.not(deletion_motive: :self_deleted)
       .or(where(deletion_motive: nil))
-      .where(submission_id: nil)
+      .where(assignment_id: nil)
   end
 
   def contextualization
@@ -135,5 +135,9 @@ class Message < ApplicationRecord
 
   def disapprove!
     update! approved: false, approved_at: nil, approved_by: nil
+  end
+
+  def ensure_contextualized
+    errors.add(:base, :not_properly_contextualized) unless contextualized?
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,17 +2,47 @@ class Message < ApplicationRecord
   include WithSoftDeletion
 
   belongs_to :discussion, optional: true
-  belongs_to :assignment, foreign_key: :submission_id, primary_key: :submission_id, optional: true
+  belongs_to :assignment, optional: true
   belongs_to :approved_by, class_name: 'User', optional: true
 
   has_one :exercise, through: :assignment
 
   validates_presence_of :content, :sender
-  validates_presence_of :submission_id, :unless => :discussion_id?
+  validate :contextualized?
 
   after_save :update_counters_cache!
 
   markdown_on :content
+
+  # Visible messages are those that can be publicly seen
+  # in forums. non-direct messages are naver visible.
+  scope :visible, -> () do
+    where.not(deletion_motive: :self_deleted)
+      .or(where(deletion_motive: nil))
+      .where(submission_id: nil)
+  end
+
+  def contextualization
+    direct? ? assignment : discussion
+  end
+
+  def contextualized?
+    assignment_id.present? ^ discussion_id.present?
+  end
+
+  # Whether this message is stale, that is,
+  # targets a submission that is the latest one.
+  #
+  # This can occur only in direct messages.
+  def stale?
+    direct? && assignment.submission_id != submission_id
+  end
+
+  # Whether this message is direct, that is, whether it comes from rise-hand feature.
+  # Forum messages are non-direct.
+  def direct?
+    submission_id.present?
+  end
 
   def notify!
     Mumukit::Nuntius.notify! 'student-messages', to_resource_h unless Organization.silenced?
@@ -85,23 +115,19 @@ class Message < ApplicationRecord
     self
   end
 
-  def self.parse_json(json)
-    message = json.delete 'message'
-    json
-        .except('uid', 'exercise_id')
-        .merge(message)
-  end
-
   def self.read_all!
     update_all read: true
   end
 
-  def self.import_from_resource_h!(json)
-    message_data = parse_json json
-    Organization.find_by!(name: message_data.delete('organization')).switch!
+  def self.import_from_resource_h!(resource_h)
+    ## TODO AVOID SWITCH
+    Organization.locate!(resource_h['organization']).switch!
 
-    if message_data['submission_id'].present?
-      Assignment.find_by(submission_id: message_data.delete('submission_id'))&.receive_answer! message_data
+    ## TODO find by assignment_id
+    if resource_h['submission_id'].present?
+      assignment = Assignment.find_by(submission_id: resource_h['submission_id'])
+      assignment&.receive_answer! sender: resource_h['message']['sender'],
+                                  content: resource_h['message']['content']
     end
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -120,10 +120,6 @@ class Message < ApplicationRecord
   end
 
   def self.import_from_resource_h!(resource_h)
-    ## TODO AVOID SWITCH
-    Organization.locate!(resource_h['organization']).switch!
-
-    ## TODO find by assignment_id
     if resource_h['submission_id'].present?
       assignment = Assignment.find_by(submission_id: resource_h['submission_id'])
       assignment&.receive_answer! sender: resource_h['message']['sender'],

--- a/db/migrate/20210707143002_add_assignment_id_to_message.rb
+++ b/db/migrate/20210707143002_add_assignment_id_to_message.rb
@@ -1,0 +1,5 @@
+class AddAssignmentIdToMessage < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :messages, :assignment, index: true
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210518100153) do
+ActiveRecord::Schema.define(version: 20210707143002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -385,7 +385,9 @@ ActiveRecord::Schema.define(version: 20210518100153) do
     t.integer "deletion_motive"
     t.datetime "deleted_at"
     t.bigint "deleted_by_id"
+    t.bigint "assignment_id"
     t.index ["approved_by_id"], name: "index_messages_on_approved_by_id"
+    t.index ["assignment_id"], name: "index_messages_on_assignment_id"
     t.index ["deleted_by_id"], name: "index_messages_on_deleted_by_id"
   end
 

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -38,6 +38,11 @@ describe Assignment, organization_workspace: :test do
       it { expect(message.read).to be false }
       it { expect(message.assignment).to eq assignment }
       it { expect(message.submission_id).to eq assignment.submission_id }
+      it { expect(message.assignment_id).to eq assignment.id }
+      it { expect(message.contextualization).to eq assignment }
+      it { expect(message.contextualized?).to be true }
+      it { expect(message.stale?).to be false }
+      it { expect(message.direct?).to be true }
       it { expect(assignment.organization).to eq Organization.current }
     end
   end

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -8,6 +8,7 @@ describe Discussion, organization_workspace: :test do
     let(:problem) { create(:indexed_exercise) }
     let(:discussion) { problem.discuss! initiator, title: 'Need help' }
     let(:moderator) { create(:user, permissions: {moderator: 'test/*'}) }
+    let(:first_message) { discussion.messages.first }
 
     it { expect(discussion.new_record?).to be false }
     it { expect(discussion.has_responses?).to be false }
@@ -30,12 +31,17 @@ describe Discussion, organization_workspace: :test do
 
       it { expect(discussion.has_responses?).to be false }
       it { expect(discussion.has_validated_responses?).to be false }
-      it { expect(discussion.messages.first.content).to eq 'I forgot to say this' }
       it { expect(initiator.unread_discussions).to eq [] }
       it { expect(discussion.reachable_statuses_for initiator).to eq [:closed] }
       it { expect(discussion.reachable_statuses_for moderator).to eq [:closed] }
       it { expect(discussion.reachable_statuses_for student).to eq [] }
       it { expect(discussion.requires_moderator_response).to be true }
+
+      it { expect(first_message.content).to eq 'I forgot to say this' }
+      it { expect(first_message.contextualization).to eq discussion }
+      it { expect(first_message.contextualized?).to be true }
+      it { expect(first_message.stale?).to be false }
+      it { expect(first_message.direct?).to be false }
 
       describe 'and closes the discussion' do
         before { discussion.update_status!(:closed, initiator) }
@@ -70,7 +76,7 @@ describe Discussion, organization_workspace: :test do
       it { expect(discussion.has_responses?).to be true }
       it { expect(discussion.has_validated_responses?).to be false }
       it { expect(initiator.unread_discussions).to include discussion }
-      it { expect(discussion.messages.first.content).to eq 'You should do this' }
+      it { expect(first_message.content).to eq 'You should do this' }
       it { expect(discussion.reachable_statuses_for initiator).to eq [:pending_review] }
       it { expect(discussion.reachable_statuses_for moderator).to eq [:closed, :solved] }
       it { expect(discussion.reachable_statuses_for student).to eq [] }

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -471,28 +471,6 @@ describe Exercise, organization_workspace: :test do
     it { expect(Problem.find(exercise.friendly_name)).to eq exercise }
   end
 
-  describe 'messages_path_for', organization_workspace: :test do
-    let(:haskell) { create(:haskell) }
-    let(:problem) { create(:problem, bibliotheca_id: 32, guide: guide, language: haskell) }
-    let(:guide) { create(:guide, slug: 'mumuki/myguide') }
-
-    context 'user with email uid' do
-      let(:student) { create(:user, uid: 'foo@bar.com') }
-
-      it { expect(problem.messages_path_for(student))
-             .to eq 'api/guides/mumuki/myguide/32/student/foo@bar.com/messages?language=haskell' }
-      it { expect(problem.messages_url_for(student))
-             .to eq 'http://test.classroom-api.localmumuki.io/api/guides/mumuki/myguide/32/student/foo@bar.com/messages?language=haskell' }
-    end
-
-    context 'user with twitter uid' do
-      let(:student) { create(:user, uid: 'twitter|12134342') }
-
-      it { expect(problem.messages_url_for(student))
-             .to eq 'http://test.classroom-api.localmumuki.io/api/guides/mumuki/myguide/32/student/twitter%7C12134342/messages?language=haskell' }
-    end
-  end
-
   describe '#splitted_description' do
     let(:exercise) { create(:exercise, description: "**Foo**\n\n> _Bar_") }
     it { expect(exercise.description_context).to eq "<p><strong>Foo</strong></p>\n" }

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,33 +1,12 @@
 require 'spec_helper'
 
 describe Message, organization_workspace: :test do
-  describe '#parse_json' do
-    let(:data) {
-      {'exercise_id' => 1,
-       'submission_id' => 'abcdef1',
-       'message' => {
-         'sender' => 'student@mumuki.org',
-         'content' => 'a',
-         'created_at' => '1/1/1'}} }
-
-    let(:expected_json) {
-      {'submission_id' => 'abcdef1',
-       'content' => 'a',
-       'created_at' => '1/1/1',
-       'sender' => 'student@mumuki.org'} }
-
-    let(:parsed_comment) { Message.parse_json(data) }
-
-    it { expect(parsed_comment).to eq(expected_json) }
-  end
-
   describe '.import_from_resource_h!' do
     let(:user) { create(:user) }
     let(:problem) { create(:problem) }
 
     context 'when last submission' do
       let!(:assignment) { problem.submit_solution! user, content: '' }
-      let(:final_assignment) { Assignment.first }
       let(:message) { Message.first }
       let(:other_organization) { create(:organization) }
 
@@ -37,7 +16,7 @@ describe Message, organization_workspace: :test do
          'organization' => Organization.current.name,
          'message' => {
            'sender' => 'teacher@mumuki.org',
-           'content' => 'a',
+           'content' => 'first message',
            'created_at' => '1/1/1'}} }
 
       before { Message.import_from_resource_h! data }
@@ -48,24 +27,31 @@ describe Message, organization_workspace: :test do
                                   'organization' => Organization.current.name,
                                   'message' => {
                                     'sender' => 'teacher@mumuki.org',
-                                    'content' => 'a',
+                                    'content' => 'second message',
                                     'created_at' => '1/1/1'}
       end
 
-      it { expect(Message.count).to eq 1 }
+      it { expect(Message.count).to eq 2 }
       it { expect(message.assignment).to_not be_nil }
-      it { expect(message.assignment).to eq final_assignment }
+      it { expect(message.assignment).to eq assignment }
+      it { expect(message.contextualization).to eq assignment }
       it { expect(message.to_resource_h.except 'created_at', 'updated_at', 'date')
              .to json_like submission_id: message.submission_id,
-                           content: 'a',
+                           assignment_id: message.assignment_id,
+                           content: 'first message',
                            sender: 'teacher@mumuki.org',
                            read: false,
                            exercise: {bibliotheca_id: problem.bibliotheca_id},
                            organization: 'test' }
-      it { expect(final_assignment.has_messages?).to be true }
-      it { expect(user.messages.count).to eq 1 }
-      it { expect(user.messages_in_organization.count).to eq 1 }
+      it { expect(assignment.has_messages?).to be true }
+
+      it { expect(user.messages_in_organization.count).to eq 2 }
       it { expect(user.messages_in_organization(other_organization).count).to eq 0 }
+      it { expect(user.messages_in_organization.map(&:content)).to eq ['second message', 'first message'] }
+      it { expect(user.messages_in_organization.map(&:stale?)).to eq [false, true] }
+      it { expect(user.messages_in_organization.map(&:direct?)).to eq [true, true] }
+      it { expect(user.messages_in_organization.map(&:contextualized?)).to eq [true, true] }
+
     end
 
     context 'when not last submission' do
@@ -85,7 +71,7 @@ describe Message, organization_workspace: :test do
 
       it { expect(Message.count).to eq 0 }
       it { expect(Assignment.first.has_messages?).to be false }
+      it { expect(user.messages_in_organization.count).to eq 0 }
     end
-
   end
 end


### PR DESCRIPTION
# :dart: Goal

To introduce `stale` message, which allows platform to track messages sent to previous submissions. 

# :memo: Details

This PR has some important side effects: 

1. An `assignment_id` indexed column has been introduced. This also improves join performance when trying to get messages associated to assignments. That is why I am reverting ba73da87fb2c67cd9db4b9da2fce50c2ba9e539d
2. I have somewhat reified the concept of `direct` - rise hand - messages, as opposed to non-direct ones - forum messages. 
3. I have rewritten the `import_from_resource_h` method, since it basically allowed data without validation to be entered through the private queue. 
4. `stale?`, `direct?` and `contextualization`  messages were introduced. They have no direct usage right now, but are exposed for the future.  

Also, I have refactored `visible_messages`, in order to have that concern in the `Message` class. 

# :back: Backwards compatibility

This PR is **not** fully backwards compatible, since: 

* Now previous messages will be kept, changing results of the `messages` methods
* Previously created messages will **not** be joined from now on, since only `assignment_id` will be used. Keeping them will require an additional migration

# :soon: Future work

* I think that we should rename many `messages` associations to `direct_messages` to keep things more intention revealing
* We should change `sender` column to a `sender_id`, in order to avoid joining users using a plain uid.  
