### PR TITLE
Fix save submission

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -82,7 +82,7 @@ class Assignment < Progress
     end
   end
 
-  def persist_submission!(submission)
+  def save_submission!(submission)
     transaction do
       update! submission_id: submission.id
       update! submitted_at: Time.current

--- a/app/models/exercise/playground.rb
+++ b/app/models/exercise/playground.rb
@@ -3,9 +3,9 @@ class Playground < QueriableChallenge
 
   name_model_as Exercise
 
-  def setup_query_assignment!(assignment, submission)
+  def save_query_submission!(assignment, submission)
     assignment.running!
-    assignment.persist_submission! submission
+    assignment.save_submission! submission
   end
 
   def save_query_results!(assignment)

--- a/app/models/exercise/playground.rb
+++ b/app/models/exercise/playground.rb
@@ -3,8 +3,9 @@ class Playground < QueriableChallenge
 
   name_model_as Exercise
 
-  def setup_query_assignment!(assignment)
+  def setup_query_assignment!(assignment, submission)
     assignment.running!
+    assignment.persist_submission! submission
   end
 
   def save_query_results!(assignment)

--- a/app/models/exercise/problem.rb
+++ b/app/models/exercise/problem.rb
@@ -9,7 +9,7 @@ class Problem < QueriableChallenge
 
   name_model_as Exercise
 
-  def setup_query_assignment!(assignment)
+  def setup_query_assignment!(_assignment, _submission)
   end
 
   def save_query_results!(assignment)

--- a/app/models/exercise/problem.rb
+++ b/app/models/exercise/problem.rb
@@ -9,7 +9,7 @@ class Problem < QueriableChallenge
 
   name_model_as Exercise
 
-  def setup_query_assignment!(_assignment, _submission)
+  def save_query_submission!(_assignment, _submission)
   end
 
   def save_query_results!(assignment)

--- a/lib/mumuki/domain/factories/exercise_factory.rb
+++ b/lib/mumuki/domain/factories/exercise_factory.rb
@@ -28,12 +28,20 @@ FactoryBot.define do
   end
 
   factory :exercise_base do
+    transient do
+      indexed { false }
+    end
+
     language { guide ? guide.language : create(:language) }
     sequence(:bibliotheca_id) { |n| n }
     sequence(:number) { |n| n }
 
     locale { :en }
     guide
+
+    after(:build) do |exercise, evaluator|
+      exercise.guide = create(:indexed_guide) if evaluator.indexed
+    end
   end
 
   factory :challenge, parent: :exercise_base do
@@ -73,7 +81,7 @@ FactoryBot.define do
   factory :exercise, parent: :problem
 
   factory :indexed_exercise, parent: :exercise do
-    guide { create(:indexed_guide) }
+    indexed { true }
   end
 
   factory :x_equal_5_exercise, parent: :exercise do

--- a/lib/mumuki/domain/submission/persistent_submission.rb
+++ b/lib/mumuki/domain/submission/persistent_submission.rb
@@ -2,6 +2,6 @@ class Mumuki::Domain::Submission::PersistentSubmission < Mumuki::Domain::Submiss
   def save_submission!(assignment)
     assignment.running!
     super
-    assignment.persist_submission! self
+    assignment.save_submission! self
   end
 end

--- a/lib/mumuki/domain/submission/query.rb
+++ b/lib/mumuki/domain/submission/query.rb
@@ -6,7 +6,7 @@ class Mumuki::Domain::Submission::Query < Mumuki::Domain::Submission::ConsoleSub
   end
 
   def save_submission!(assignment)
-    assignment.exercise.setup_query_assignment!(assignment, self)
+    assignment.exercise.save_query_submission!(assignment, self)
     super
   end
 

--- a/lib/mumuki/domain/submission/query.rb
+++ b/lib/mumuki/domain/submission/query.rb
@@ -6,7 +6,7 @@ class Mumuki::Domain::Submission::Query < Mumuki::Domain::Submission::ConsoleSub
   end
 
   def save_submission!(assignment)
-    assignment.exercise.setup_query_assignment!(assignment)
+    assignment.exercise.setup_query_assignment!(assignment, self)
     super
   end
 

--- a/lib/mumuki/domain/submission/question.rb
+++ b/lib/mumuki/domain/submission/question.rb
@@ -5,7 +5,6 @@ class Mumuki::Domain::Submission::Question < Mumuki::Domain::Submission::Base
   end
 
   def save_submission!(assignment)
-    assignment.persist_submission! self
   end
 
   def try_evaluate!(*)

--- a/lib/mumuki/domain/submission/try.rb
+++ b/lib/mumuki/domain/submission/try.rb
@@ -8,6 +8,7 @@ class Mumuki::Domain::Submission::Try < Mumuki::Domain::Submission::ConsoleSubmi
   def save_submission!(assignment)
     assignment.query_results = [] if cookie.blank?
     assignment.queries = cookie.insert_last(query)
+    assignment.persist_submission! self
     assignment.save!
   end
 

--- a/lib/mumuki/domain/submission/try.rb
+++ b/lib/mumuki/domain/submission/try.rb
@@ -8,7 +8,7 @@ class Mumuki::Domain::Submission::Try < Mumuki::Domain::Submission::ConsoleSubmi
   def save_submission!(assignment)
     assignment.query_results = [] if cookie.blank?
     assignment.queries = cookie.insert_last(query)
-    assignment.persist_submission! self
+    assignment.save_submission! self
     assignment.save!
   end
 

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -14,24 +14,29 @@ describe Mumuki::Domain::Submission::Query do
     shared_examples_for 'a query submission' do
       it { expect(results[:status]).to eq :passed }
       it { expect(results[:result]).to eq '5' }
-      it { expect(assignment.solution).to eq 'bar' }
-      it { expect(assignment.status).to eq :pending }
     end
 
     context 'a playground exercise' do
-      let(:exercise) { create(:playground) }
+      let(:exercise) { create(:playground, indexed: true) }
 
       it_behaves_like 'a query submission'
+
       it { expect(assignment.submission_id).to_not be nil }
       it { expect(assignment.submitted_at).to_not be nil }
+
+      it { expect(assignment.solution).to be nil }
+      it { expect(assignment.status).to eq :passed }
     end
 
     context 'a problem problem' do
-      let(:exercise) { create(:playground) }
+      let(:exercise) { create(:problem, indexed: true) }
 
       it_behaves_like 'a query submission'
       it { expect(assignment.submission_id).to be nil }
       it { expect(assignment.submitted_at).to be nil }
+
+      it { expect(assignment.solution).to eq 'bar' }
+      it { expect(assignment.status).to eq :pending }
     end
   end
 end

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -28,7 +28,7 @@ describe Mumuki::Domain::Submission::Query do
       it { expect(assignment.status).to eq :passed }
     end
 
-    context 'a problem problem' do
+    context 'a problem exercise' do
       let(:exercise) { create(:problem, indexed: true) }
 
       it_behaves_like 'a query submission'

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Mumuki::Domain::Submission::Query do
-  let!(:exercise) { create(:exercise) }
   let(:user) { create(:user) }
 
   before do
@@ -12,9 +11,27 @@ describe Mumuki::Domain::Submission::Query do
     let!(:results) { exercise.submit_query!(user, query: 'foo', content: 'bar', cookie: ['foo', 'bar']) }
     let(:assignment) { exercise.find_assignment_for(user, Organization.current) }
 
-    it { expect(results[:status]).to eq :passed }
-    it { expect(results[:result]).to eq '5' }
-    it { expect(assignment.solution).to eq 'bar' }
-    it { expect(assignment.status).to eq :pending }
+    shared_examples_for 'a query submission' do
+      it { expect(results[:status]).to eq :passed }
+      it { expect(results[:result]).to eq '5' }
+      it { expect(assignment.solution).to eq 'bar' }
+      it { expect(assignment.status).to eq :pending }
+    end
+
+    context 'a playground exercise' do
+      let(:exercise) { create(:playground) }
+
+      it_behaves_like 'a query submission'
+      it { expect(assignment.submission_id).to_not be nil }
+      it { expect(assignment.submitted_at).to_not be nil }
+    end
+
+    context 'a problem problem' do
+      let(:exercise) { create(:playground) }
+
+      it_behaves_like 'a query submission'
+      it { expect(assignment.submission_id).to be nil }
+      it { expect(assignment.submitted_at).to be nil }
+    end
   end
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -16,13 +16,15 @@ describe Mumuki::Domain::Submission::Query, organization_workspace: :test do
       it { expect(assignment.solution).to be nil }
       it { expect(assignment.messages.count).to eq 1 }
       it { expect(assignment.submission_id).to be nil }
+      it { expect(assignment.submitted_at).to be nil }
     end
 
     context 'when a question on a previous submission is sent' do
       before do
-        assignment = exercise.submit_solution!(student, content: 'x = 1')
+        assignment = exercise.submit_solution!(student, content: 'x = 1').reload
         assignment.failed!
         @original_submission_id = assignment.submission_id
+        @original_submitted_at = assignment.submitted_at
       end
 
       before { exercise.submit_question!(student, content: 'Please help!') }
@@ -32,6 +34,7 @@ describe Mumuki::Domain::Submission::Query, organization_workspace: :test do
       it { expect(assignment.solution).to eq 'x = 1' }
       it { expect(assignment.messages.count).to eq 1 }
       it { expect(assignment.submission_id).to eq @original_submission_id }
+      it { expect(assignment.submitted_at).to eq @original_submitted_at }
     end
   end
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -15,7 +15,7 @@ describe Mumuki::Domain::Submission::Query, organization_workspace: :test do
 
       it { expect(assignment.solution).to be nil }
       it { expect(assignment.messages.count).to eq 1 }
-      it { expect(assignment.submission_id).to_not be nil }
+      it { expect(assignment.submission_id).to be nil }
     end
 
     context 'when a question on a previous submission is sent' do


### PR DESCRIPTION
# :dart: Goal

To ensure that submissions generate a `submitted_at` as approrpiate 

# :memo: Details

With this PR: 

* Questions won't update `submitted_at` anymore
* Playground will update it
* Tries and Problems will continue to update it.  
* Queries on problem will continue to **not** update it

# :warning: Dependencies

* #222 
* #226 

# :back: Backwards compatibility

This PR should be backwards compatible, since the previous behavior was never intended. Issue https://github.com/mumuki/mumuki-domain/pull/223 is an example of the consequences of such obscure code. 

