### PR TITLE
Use submitted_at on activity date filters again

### DIFF
--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -11,7 +11,7 @@ class UserStats < ApplicationRecord
   end
 
   def activity(date_range = nil)
-    date_filter = { updated_at: date_range }.compact
+    date_filter = { submitted_at: date_range }.compact
     {
         exercises: {
             solved_count: organization_exercises

--- a/spec/models/user_stats_spec.rb
+++ b/spec/models/user_stats_spec.rb
@@ -27,7 +27,7 @@ describe UserStats, organization_workspace: :test do
         exercises[0].submit_solution!(user, content: '').failed!
 
         assignment = exercises[1].submit_solution!(user, content: '')
-        assignment.update!(updated_at: 2.days.until, status: 'skipped')
+        assignment.update!(submitted_at: 2.days.until, status: 'skipped')
 
         exercises[0].submit_solution!(another_user, content: '').passed!
       end


### PR DESCRIPTION
## :dart: Goal

Revert https://github.com/mumuki/mumuki-domain/pull/223.

## :memo: Details

While that pull request's "Future Work" mentioned we should revert it three months after its implementation, we decided we'll instead make sure no assignments with `submitted_at: nil` remain in the database (for assignments where the status is not pending, which means an actual submission was made). This is a cleaner approach as all data is kept in a consistent state, instead of behavior that depends on the row's date.
