### PR TITLE
Fix discussion notifications

### DIFF
--- a/app/models/concerns/with_discussion_creation/subscription.rb
+++ b/app/models/concerns/with_discussion_creation/subscription.rb
@@ -8,7 +8,7 @@ module WithDiscussionCreation::Subscription
   end
 
   def subscriptions_in_organization
-    subscriptions.joins(:discussion).where(discussion: discussions_in_organization)
+    subscriptions.where(discussion: Organization.current.discussions)
   end
 
   def subscribed_to?(discussion)

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -21,7 +21,7 @@ class Discussion < ApplicationRecord
   scope :no_responsible_moderator, -> { where('responsible_moderator_at < ?', Time.now - MODERATOR_MAX_RESPONSIBLE_TIME)
                                           .or(where(responsible_moderator_at: nil)) }
   scope :pending_review, -> { where(status: :pending_review) }
-  scope :unread_first, -> { (includes(:subscriptions).reorder('subscriptions.read')) }
+  scope :unread_first, -> { includes(:subscriptions).reorder('subscriptions.read', :created_at) }
 
   after_create :subscribe_initiator!
 

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -97,7 +97,7 @@ class Discussion < ApplicationRecord
   end
 
   def mark_subscriptions_as_unread!(user)
-    subscriptions.where.not(user: user).map(&:unread!)
+    subscriptions.where.not(user: user).each(&:unread!)
   end
 
   def submit_message!(message, user)

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -96,7 +96,7 @@ class Discussion < ApplicationRecord
     upvotes.find_by(user: user)
   end
 
-  def unread_subscriptions(user)
+  def mark_subscriptions_as_unread!(user)
     subscriptions.where.not(user: user).map(&:unread!)
   end
 
@@ -104,7 +104,7 @@ class Discussion < ApplicationRecord
     message.merge!(sender: user.uid)
     messages.create(message)
     user.subscribe_to! self
-    unread_subscriptions(user)
+    mark_subscriptions_as_unread!(user)
     no_responsible! if responsible?(user)
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -148,6 +148,10 @@ class Organization < ApplicationRecord
     [default_date, in_preparation_until&.to_date].compact.max
   end
 
+  def discussions
+    book.discussions_in_organization(self)
+  end
+
   # ==============
   # Display fields
   # ==============

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe WithDiscussionCreation::Subscription, organization_workspace: :test do
+  let(:user) { create(:user) }
+  let(:subscriber) { create(:user) }
+  let(:problem) { create(:indexed_exercise) }
+
+  describe 'discussion is created' do
+    let!(:discussion) { problem.discuss! user, title: 'Need help' }
+    let(:subscription) { Subscription.where(user: user).first }
+
+    it { expect(Subscription.count).to eq 1 }
+    it { expect(discussion.subscription_for(user)).to eq subscription }
+    it { expect(subscription.discussion).to eq discussion }
+    it { expect(subscription.read).to be true }
+    it { expect(user.subscribed_to? discussion).to be true }
+  end
+
+  describe 'user subscribes to another user\'s discussion' do
+    let!(:discussion) { problem.discuss! user, title: 'Need help' }
+    let(:subscription) { Subscription.where(user: subscriber).first }
+
+    before { subscriber.subscribe_to! discussion }
+
+    it { expect(discussion.subscription_for(subscriber)).to eq subscription }
+    it { expect(subscription.read).to be true }
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -38,4 +38,31 @@ describe WithDiscussionCreation::Subscription, organization_workspace: :test do
       it {expect(discussion.subscription_for(subscriber)).to be nil }
     end
   end
+
+  describe 'discussions in different organizations' do
+    let(:test_organization) { Organization.locate!('test') }
+    let(:another_organization) { create(:organization, book: test_organization.book) }
+
+    before do
+      problem.discuss! user, title: 'Need help'
+      user.subscribe_to! (problem.discuss!(create(:user), title: 'Need help'))
+
+      another_organization.switch!
+      problem.discuss! user, title: 'Need help'
+      problem.discuss! user, title: 'Need help'
+      user.subscribe_to! (problem.discuss!(create(:user), title: 'Need help'))
+    end
+
+    context 'in test organization' do
+      before { test_organization.switch! }
+
+      it { expect(user.subscriptions_in_organization.count).to eq 2 }
+    end
+
+    context 'in another organization' do
+      before { another_organization.switch! }
+
+      it { expect(user.subscriptions_in_organization.count).to eq 3 }
+    end
+  end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -24,5 +24,18 @@ describe WithDiscussionCreation::Subscription, organization_workspace: :test do
 
     it { expect(discussion.subscription_for(subscriber)).to eq subscription }
     it { expect(subscription.read).to be true }
+
+    context 'when someone posts a message' do
+      before { discussion.submit_message!({content: 'Same here'}, create(:user)) }
+
+      it { expect(discussion.subscription_for(user).read).to be false }
+      it { expect(discussion.subscription_for(subscriber).read).to be false }
+    end
+
+    context 'when user unsubscribes' do
+      before { subscriber.unsubscribe_to! discussion }
+
+      it {expect(discussion.subscription_for(subscriber)).to be nil }
+    end
   end
 end


### PR DESCRIPTION
## :dart: Goal

Fix a bug where notifications for discussions a user has subscribed to were not being shown. Also, add a few subscription tests.

## :memo: Details

When asking for a user's `unread_discussions`, you'd only get those where the user was the initiator. Since that method is used for notifications, there were actually no notifications shown for discussions where the user was not the initiator. (The discussion _would_ show on the profile, though, whether read or unread, as that is done through `watched_discussions`). This would cause a mismatch between the number of notifications and the actual number of unread discussions, as some of them were not being considered (namely, all those that the user didn't create).

In the most extreme cases, such as that of moderators, they would never get any notifications, as they don't create discussions but do get subscribed when they post a message.

I'll add a comment on the affected lines to clarify further.

## :soon: Future work

I found this other bug https://github.com/mumuki/mumuki-domain/issues/232 while fixing this one, but it's less important. 
