### PR TITLE
User post! instead of deliver_now / deliver_later

### DIFF
--- a/app/models/concerns/with_reminders.rb
+++ b/app/models/concerns/with_reminders.rb
@@ -10,7 +10,7 @@ module WithReminders
   end
 
   def remind!
-    build_reminder.deliver_now
+    build_reminder.post!
     update! last_reminded_date: Time.current
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -300,7 +300,7 @@ class User < ApplicationRecord
   def certificate_in(certificate_program, certificate_h)
     return if certificated_in?(certificate_program)
     certificate = certificates.create certificate_h.merge(certificate_program: certificate_program)
-    UserMailer.certificate(certificate).deliver_later
+    UserMailer.certificate(certificate).post!
   end
 
   def clear_progress_for!(organization)
@@ -316,7 +316,7 @@ class User < ApplicationRecord
   end
 
   def notify_via_email!(notification)
-    UserMailer.notification(notification).deliver_later unless ignores_notification? notification
+    UserMailer.notification(notification).post! unless ignores_notification? notification
   end
 
   def ignores_notification?(notification)
@@ -327,7 +327,7 @@ class User < ApplicationRecord
 
   def welcome_to_new_organizations!
     new_accessible_organizations.each do |organization|
-      UserMailer.welcome_email(self, organization).deliver_now rescue nil if organization.greet_new_users?
+      UserMailer.welcome_email(self, organization).post! rescue nil if organization.greet_new_users?
     end
   end
 


### PR DESCRIPTION
## :dart: Goal
Use `post!` message to choose appropiate email delivery method.

## :memo: Details
Emails should be sent with deliver_now when running rake tasks and deliver_later when running `rails s`

## :warning: Dependencies
Two way dependency: https://github.com/mumuki/mumuki-laboratory/pull/1655.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.
