### PR TITLE
Chore notification improvements

### DIFF
--- a/app/models/concerns/with_notifications.rb
+++ b/app/models/concerns/with_notifications.rb
@@ -7,7 +7,7 @@ module WithNotifications
 
   def unread_notifications
     # TODO: message and discussion should trigger a notification instead of being one
-    all = notifications.where(read: false) + unread_messages + unread_discussions
+    all = notifications_in_organization.where(read: false) + unread_messages + unread_discussions
     all.sort_by(&:created_at).reverse
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,10 @@ class User < ApplicationRecord
     messages.where('assignments.organization': organization)
   end
 
+  def notifications_in_organization(organization = Organization.current)
+    notifications.where(organization: organization)
+  end
+
   def passed_submissions_count_in(organization)
     assignments.where(top_submission_status: Mumuki::Domain::Status::Submission::Passed.to_i, organization: organization).count
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,6 +54,8 @@ class User < ApplicationRecord
   resource_fields :uid, :social_id, :email, :permissions, :verified_first_name, :verified_last_name, *profile_fields
   with_temporary_token :delete_account_token
 
+  organic_on :notifications
+
   def last_lesson
     last_guide.try(:lesson)
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -805,4 +805,17 @@ describe User, organization_workspace: :test do
       it { expect(user.ignores_notification? notification).to be false }
     end
   end
+
+  describe '#notifications_in_organization' do
+    let(:user) { create(:user) }
+    let(:organization) { create(:organization) }
+    let!(:notification1) { create(:notification, user: user, organization: organization) }
+    let!(:notification2) { create(:notification, user: user) }
+
+    let(:notifications_in_organization) { user.notifications_in_organization(organization) }
+
+    it { expect(user.notifications.count).to eq 2 }
+    it { expect(notifications_in_organization.count).to eq 1 }
+    it { expect(notifications_in_organization).to eq [notification1] }
+  end
 end


### PR DESCRIPTION
## :dart: Goal
Add method for showing only current organization notifications.

## :memo: Details
Adding `notifications_in_organization` similarly to messages and discussions methods we already have.

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.
