### PR TITLE
Fix assignment content updating on queries

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -43,20 +43,6 @@ class Assignment < Progress
   after_initialize :set_default_top_submission_status
   before_save :award_experience_points!, :update_top_submission!, if: :submission_status_changed?
   after_save :dirty_parent_by_submission!, if: :completion_changed?
-  before_validation :set_current_organization!, unless: :organization
-
-  # TODO: Momentary as some assignments may not have an associated organization
-  def set_current_organization!
-    self.organization = Organization.current
-  end
-
-  def recontextualize!(new_organization = Organization.current)
-    if organization != new_organization
-      dirty_parent_by_submission! if organization.present? && exercise.used_in?(organization)
-      self.organization = new_organization
-      self.parent_id = nil
-    end
-  end
 
   def set_default_top_submission_status
     self.top_submission_status ||= 0

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -109,7 +109,7 @@ class Assignment < Progress
   end
 
   def content=(content)
-    if content.present? && exercise.solvable?
+    if exercise.solvable?
       self.solution = exercise.single_choice? ? exercise.choice_index_for(content) : content
     end
   end

--- a/lib/mumuki/domain/submission/base.rb
+++ b/lib/mumuki/domain/submission/base.rb
@@ -52,7 +52,6 @@ class Mumuki::Domain::Submission::Base
   private
 
   def save_submission!(assignment)
-    assignment.content = content
     assignment.recontextualize!
     assignment.save!
   end

--- a/lib/mumuki/domain/submission/base.rb
+++ b/lib/mumuki/domain/submission/base.rb
@@ -52,7 +52,6 @@ class Mumuki::Domain::Submission::Base
   private
 
   def save_submission!(assignment)
-    assignment.recontextualize!
     assignment.save!
   end
 

--- a/lib/mumuki/domain/submission/persistent_submission.rb
+++ b/lib/mumuki/domain/submission/persistent_submission.rb
@@ -1,5 +1,6 @@
 class Mumuki::Domain::Submission::PersistentSubmission < Mumuki::Domain::Submission::Base
   def save_submission!(assignment)
+    assignment.content = content
     assignment.running!
     super
     assignment.save_submission! self

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -200,7 +200,7 @@ describe Assignment, organization_workspace: :test do
   describe 'update_misplaced!' do
     let(:exercise) { create(:exercise) }
     let(:user) { create(:user) }
-    let(:assignment) { Assignment.create(exercise: exercise, submitter: user, misplaced: misplaced) }
+    let(:assignment) { Assignment.create(exercise: exercise, submitter: user, misplaced: misplaced, organization: Organization.current) }
 
     context 'when nil' do
       let(:misplaced) { nil }

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -21,10 +21,10 @@ describe Mumuki::Domain::Submission::Query do
 
       it_behaves_like 'a query submission'
 
-      it { expect(assignment.submission_id).to_not be nil }
-      it { expect(assignment.submitted_at).to_not be nil }
+      it { expect(assignment.submission_id).to_not be_nil }
+      it { expect(assignment.submitted_at).to_not be_nil }
 
-      it { expect(assignment.solution).to be nil }
+      it { expect(assignment.solution).to be_nil }
       it { expect(assignment.status).to eq :passed }
     end
 
@@ -32,10 +32,10 @@ describe Mumuki::Domain::Submission::Query do
       let(:exercise) { create(:problem, indexed: true) }
 
       it_behaves_like 'a query submission'
-      it { expect(assignment.submission_id).to be nil }
-      it { expect(assignment.submitted_at).to be nil }
+      it { expect(assignment.submission_id).to be_nil }
+      it { expect(assignment.submitted_at).to be_nil }
 
-      it { expect(assignment.solution).to eq 'bar' }
+      it { expect(assignment.solution).to be_nil }
       it { expect(assignment.status).to eq :pending }
     end
   end

--- a/spec/models/solution_spec.rb
+++ b/spec/models/solution_spec.rb
@@ -190,7 +190,7 @@ describe Mumuki::Domain::Submission::Solution, organization_workspace: :test do
       before { exercise.submit_solution!(user, content: '') }
 
       it { expect(assignment.reload.status).to eq :failed }
-      pending { expect(assignment.reload.solution).to be_empty }
+      it { expect(assignment.reload.solution).to be_empty }
     end
   end
 end


### PR DESCRIPTION
## :dart: Goal
Stop queries from updating assignment content.

## :memo: Details
Moving content update logic to `PersistentSubmission`.
Also removing some logic I believe to be stale now that we have progress separated by organization?

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.