### PR TITLE
Add useful exam registration methods

### DIFF
--- a/app/models/exam_registration.rb
+++ b/app/models/exam_registration.rb
@@ -76,6 +76,10 @@ class ExamRegistration < ApplicationRecord
     authorization_criterion.meets_criterion?(user, organization)
   end
 
+  def multiple_options?
+    exams.count > 1
+  end
+
   private
 
   def notify_registree!(registree)

--- a/app/models/exam_registration.rb
+++ b/app/models/exam_registration.rb
@@ -80,6 +80,10 @@ class ExamRegistration < ApplicationRecord
     exams.count > 1
   end
 
+  def ended?
+    end_time.past?
+  end
+
   private
 
   def notify_registree!(registree)

--- a/spec/models/exam_registration_spec.rb
+++ b/spec/models/exam_registration_spec.rb
@@ -190,4 +190,18 @@ describe ExamRegistration, organization_workspace: :test do
       it { expect(registration.reload.multiple_options?).to be true }
     end
   end
+
+  describe '#ended?' do
+    context 'when it ended' do
+      before { registration.update! end_time: DateTime.yesterday }
+
+      it { expect(registration.ended?).to be true }
+    end
+
+    context 'when it did not end' do
+      before { registration.update! end_time: DateTime.current.next_week }
+
+      it { expect(registration.ended?).to be false }
+    end
+  end
 end

--- a/spec/models/exam_registration_spec.rb
+++ b/spec/models/exam_registration_spec.rb
@@ -176,4 +176,18 @@ describe ExamRegistration, organization_workspace: :test do
       end
     end
   end
+
+  describe '#multiple_options?' do
+    let!(:exam) { create(:exam, exam_registrations: [registration]) }
+
+    context 'when there is one option only' do
+      it { expect(registration.multiple_options?).to be false }
+    end
+
+    context 'when there are multiple options' do
+      let!(:another_exam) { create(:exam, exam_registrations: [registration]) }
+
+      it { expect(registration.reload.multiple_options?).to be true }
+    end
+  end
 end


### PR DESCRIPTION
## :dart: Goal

Add a few methods needed for the corresponding Laboratory PR.

## :memo: Details

Extract `ended?` for exam registrations as there were repeated uses of `end_time.past?`.

Also, add `multiple_options?` for knowing if there are multiple exams associated with that registration.

## :back: Backwards compatibility

Yes

## :bookmark: See also

https://github.com/mumuki/mumuki-laboratory/pull/1667
