### PR TITLE
Add criterion matcher to authorization criterior

### DIFF
--- a/app/models/exam_registration.rb
+++ b/app/models/exam_registration.rb
@@ -12,7 +12,7 @@ class ExamRegistration < ApplicationRecord
 
   before_save :ensure_valid_authorization_criterion!
 
-  delegate :meets_authorization_criteria?, :process_request!, to: :authorization_criterion
+  delegate :meets_authorization_criteria?, :process_request!, :authorization_criteria_matcher, to: :authorization_criterion
 
   alias_attribute :name, :description
 

--- a/app/models/exam_registration/authorization_criterion.rb
+++ b/app/models/exam_registration/authorization_criterion.rb
@@ -38,6 +38,10 @@ class ExamRegistration::AuthorizationCriterion
   def meets_authorization_criteria?(authorization_request)
     meets_criterion? authorization_request.user, authorization_request.organization
   end
+
+  def authorization_criteria_matcher
+    criterion_matcher
+  end
 end
 
 class ExamRegistration::AuthorizationCriterion::None < ExamRegistration::AuthorizationCriterion
@@ -52,6 +56,10 @@ class ExamRegistration::AuthorizationCriterion::None < ExamRegistration::Authori
   def meets_criterion?(_user, _organization)
     true
   end
+
+  def criterion_matcher
+    {}
+  end
 end
 
 class ExamRegistration::AuthorizationCriterion::PassedExercises < ExamRegistration::AuthorizationCriterion
@@ -61,5 +69,9 @@ class ExamRegistration::AuthorizationCriterion::PassedExercises < ExamRegistrati
 
   def meets_criterion?(user, organization)
     user.passed_submissions_count_in(organization) >= value
+  end
+
+  def criterion_matcher
+    { 'stats.passed': { '$gte': value.to_f } }
   end
 end


### PR DESCRIPTION
## :dart: Goal
Add criterion matcher to exam registration authorization criterion

## :memo: Details
With this change will be able to filter students from mongo using the exam authorization criterion model

## :back: Backwards compatibility
100%
