### PR TITLE
Fix teacher exam accessibility

### DIFF
--- a/app/models/exam.rb
+++ b/app/models/exam.rb
@@ -49,7 +49,7 @@ class Exam < ApplicationRecord
   end
 
   def accessible_for?(user)
-    (authorized?(user) && enabled_for?(user)) || user&.teacher_here?
+    (authorized?(user) && enabled_for?(user)) || user&.teacher_of?(course)
   end
 
   def timed?

--- a/spec/models/exam_spec.rb
+++ b/spec/models/exam_spec.rb
@@ -65,17 +65,21 @@ describe Exam, organization_workspace: :test do
   end
 
   describe '#accessible_for?' do
-    context 'disabled' do
+    context 'not enabled' do
       let(:exam) { create(:exam, start_time: 5.minutes.since, end_time: 10.minutes.since, course: course) }
 
       context 'for student' do
         it { expect(exam.accessible_for? user).to be false }
       end
 
-      context 'for teacher' do
-        before { expect(user).to receive(:teacher_here?).and_return(true) }
+      context 'for teacher in course' do
+        before { user.add_permission! :teacher, course.slug }
 
         it { expect(exam.accessible_for? user).to be true }
+      end
+
+      context 'for teacher not in course' do
+        it { expect(exam.accessible_for? user).to be false }
       end
     end
 
@@ -88,10 +92,14 @@ describe Exam, organization_workspace: :test do
         it { expect(exam.accessible_for? user).to be true }
       end
 
-      context 'for teacher' do
-        before { expect(user).to receive(:teacher_here?).and_return(true) }
+      context 'for teacher in course' do
+        before { user.add_permission! :teacher, course.slug }
 
         it { expect(exam.accessible_for? user).to be true }
+      end
+
+      context 'for teacher not in course' do
+        it { expect(exam.accessible_for? user).to be false }
       end
     end
   end


### PR DESCRIPTION
## :dart: Goal

Now exams are only accessible for teachers in that exam's course, instead of being accessible for every teacher on the organization.

## :memo: Details

Refines the behavior introduced on #245.

