### PR TITLE
Feature capped exam authorizations

### DIFF
--- a/app/models/exam_registration.rb
+++ b/app/models/exam_registration.rb
@@ -76,6 +76,17 @@ class ExamRegistration < ApplicationRecord
     authorization_criterion.meets_criterion?(user, organization)
   end
 
+  def available_exams
+    return exams unless limited_authorization_requests?
+    Exam.find authorization_requests_counts.select do |_, count|
+      count <= authorization_requests_limit
+    end.keys
+  end
+
+  def limited_authorization_requests?
+    authorization_requests_limit.present?
+  end
+
   def multiple_options?
     exams.count > 1
   end
@@ -88,5 +99,9 @@ class ExamRegistration < ApplicationRecord
 
   def notify_registree!(registree)
     Notification.create_and_notify_via_email! organization: organization, user: registree, subject: :exam_registration, target: self
+  end
+
+  def authorization_requests_counts
+    authorization_requests.group(:exam).count
   end
 end

--- a/app/models/exam_registration.rb
+++ b/app/models/exam_registration.rb
@@ -97,17 +97,27 @@ class ExamRegistration < ApplicationRecord
   end
 
   def request_authorization!(user, exam)
+    validate_exam_available! exam
     authorization_requests.find_or_create_by! user: user do |it|
       it.assign_attributes organization: organization, exam: exam
     end
   end
 
   def update_authorization_request_by_id!(request_id, exam)
+    validate_exam_available! exam
     authorization_requests.update request_id, exam: exam
   end
 
   def authorization_request_ids_counts
     authorization_requests.group(:exam_id).count
+  end
+
+  def exam_available?(exam)
+    available_exams.include? exam
+  end
+
+  def validate_exam_available!(exam)
+    raise Mumuki::Domain::Gone unless exam_available?(exam)
   end
 
   private

--- a/db/migrate/20210929223144_add_authorization_requests_limit_to_exam_registration.rb
+++ b/db/migrate/20210929223144_add_authorization_requests_limit_to_exam_registration.rb
@@ -1,0 +1,5 @@
+class AddAuthorizationRequestsLimitToExamRegistration < ActiveRecord::Migration[5.1]
+  def change
+    add_column :exam_registrations, :authorization_requests_limit, :integer
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210803175124) do
+ActiveRecord::Schema.define(version: 20210929223144) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -194,6 +194,7 @@ ActiveRecord::Schema.define(version: 20210803175124) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "processed", default: false
+    t.integer "authorization_requests_limit"
     t.index ["organization_id"], name: "index_exam_registrations_on_organization_id"
   end
 

--- a/spec/models/exam_registration_spec.rb
+++ b/spec/models/exam_registration_spec.rb
@@ -5,7 +5,13 @@ describe ExamRegistration, organization_workspace: :test do
   let(:other_user) { create(:user) }
   let(:criterion_type) { :none }
   let(:criterion_value) { 0 }
-  let(:registration) { create(:exam_registration, authorization_criterion_type: criterion_type, authorization_criterion_value: criterion_value) }
+  let(:requests_limit) { nil }
+  let(:registration) do
+    create(:exam_registration,
+          authorization_criterion_type: criterion_type,
+          authorization_criterion_value: criterion_value,
+          authorization_requests_limit: requests_limit)
+  end
 
   def assignments_for(student, count)
     exercises = create_list(:indexed_exercise, count)

--- a/spec/models/exam_registration_spec.rb
+++ b/spec/models/exam_registration_spec.rb
@@ -6,11 +6,13 @@ describe ExamRegistration, organization_workspace: :test do
   let(:criterion_type) { :none }
   let(:criterion_value) { 0 }
   let(:requests_limit) { nil }
+  let(:exams) { [] }
   let(:registration) do
     create(:exam_registration,
           authorization_criterion_type: criterion_type,
           authorization_criterion_value: criterion_value,
-          authorization_requests_limit: requests_limit)
+          authorization_requests_limit: requests_limit,
+          exams: exams)
   end
 
   def assignments_for(student, count)
@@ -96,8 +98,55 @@ describe ExamRegistration, organization_workspace: :test do
         it { expect(registration.unnotified_registrees?).to be false }
       end
     end
-
   end
+
+  describe '#request_authorization!' do
+    let(:exams) { [create(:exam)] }
+
+    before { registration.request_authorization!(user, exams.first) }
+
+    it { expect(registration.authorization_requests.count).to eq 1 }
+    it { expect(registration.authorization_requests.first.exam).to eq exams.first }
+  end
+
+  describe '#update_authorization_request_by_id!' do
+    let(:exams) { [create(:exam), create(:exam)] }
+    let(:authorization) { registration.request_authorization!(user, exams.first) }
+
+    before { registration.update_authorization_request_by_id!(authorization.id, exams.second) }
+
+    it { expect(registration.authorization_requests.count).to eq 1 }
+    it { expect(registration.authorization_requests.first.exam).to eq exams.second }
+  end
+
+  describe '#available_exams!' do
+    let(:exams) { [create(:exam), create(:exam)] }
+
+    context 'when there is no limit to requests' do
+      it { expect(registration.available_exams.count).to eq 2 }
+    end
+
+    context 'when there is limit to requests' do
+      let(:requests_limit) { 3 }
+
+      context 'when limit has not yet been reached' do
+        before { registration.request_authorization!(user, exams.first) }
+
+        it { expect(registration.available_exams.count).to eq 2 }
+        it { expect(registration.authorization_request_ids_counts).to eq exams.first.id => 1 }
+      end
+
+      context 'when limit has been reached' do
+        before { 3.times { registration.request_authorization!(create(:user), exams.first) } }
+        before { registration.request_authorization!(create(:user), exams.second) }
+
+        it { expect(registration.available_exams.count).to eq 1 }
+        it { expect(registration.authorization_request_ids_counts).to eq exams.first.id => 3,
+                                                                         exams.second.id => 1 }
+      end
+    end
+  end
+
 
   describe '#process_requests!' do
     let(:criterion_type) { :passed_exercises }


### PR DESCRIPTION
## :dart: Goal

To allow exams to have a cap of students per turn. 

## :memo: Details

This feature introduces: 

* `available_exams` which contains most of the magic here
* `authorize_requests!` and `update_request_by_id!` which may look new, but is actually old code extracted from laboratory

## :back: Backwards compatibility

Backward compatible, as long as you run migrations :stuck_out_tongue: 

## :soon: Future work

It would be nice to a more detailed exception than just `Gone` which actually states that the exam is full. 

