### PR TITLE
Chore reference message sender via - Stage 1

### DIFF
--- a/app/models/concerns/with_messages.rb
+++ b/app/models/concerns/with_messages.rb
@@ -4,7 +4,7 @@ module WithMessages
   end
 
   def send_question!(question)
-    message = build_message question.merge(sender: submitter.uid, read: true)
+    message = build_message question.merge(sender: submitter, read: true)
     message.save_and_notify!
   end
 

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -103,7 +103,7 @@ class Discussion < ApplicationRecord
   end
 
   def submit_message!(message, user)
-    message.merge!(sender: user.uid)
+    message.merge!(sender: user)
     messages.create(message)
     user.subscribe_to! self
     mark_subscriptions_as_unread!(user)
@@ -142,7 +142,7 @@ class Discussion < ApplicationRecord
   end
 
   def responses_count
-    visible_messages.where.not(sender: initiator.uid).count
+    visible_messages.where.not(sender: initiator).count
   end
 
   def has_responses?

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -142,7 +142,7 @@ class Discussion < ApplicationRecord
   end
 
   def responses_count
-    visible_messages.where.not(sender: initiator).count
+    visible_messages.where('sender <> ? OR sender_id <> ?', initiator.uid, initiator.id).count
   end
 
   def has_responses?

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -4,10 +4,11 @@ class Message < ApplicationRecord
   belongs_to :discussion, optional: true
   belongs_to :assignment, optional: true
   belongs_to :approved_by, class_name: 'User', optional: true
+  belongs_to :sender, class_name: 'User'
 
   has_one :exercise, through: :assignment
 
-  validates_presence_of :content, :sender
+  validates_presence_of :content
   validate :ensure_contextualized
 
   before_create :mark_from_moderator!
@@ -50,19 +51,15 @@ class Message < ApplicationRecord
   end
 
   def from_initiator?
-    sender_user == discussion&.initiator
+    sender == discussion&.initiator
   end
 
   def from_moderator?
-    from_moderator || sender_user.moderator_here?
+    from_moderator || sender.moderator_here?
   end
 
   def from_user?(user)
-    sender_user == user
-  end
-
-  def sender_user
-    User.find_by(uid: sender)
+    sender == user
   end
 
   def authorized?(user)
@@ -75,9 +72,10 @@ class Message < ApplicationRecord
 
   def to_resource_h
     as_json(except: [:id, :type, :discussion_id, :approved, :approved_at, :approved_by_id,
-                     :not_actually_a_question, :deletion_motive, :deleted_at, :deleted_by_id, :from_moderator],
+                     :not_actually_a_question, :deletion_motive, :deleted_at, :deleted_by_id,
+                     :from_moderator, :sender_id],
             include: {exercise: {only: [:bibliotheca_id]}})
-        .merge(organization: Organization.current.name)
+        .merge(organization: Organization.current.name, sender: sender.uid)
   end
 
   def read!
@@ -127,7 +125,7 @@ class Message < ApplicationRecord
   def self.import_from_resource_h!(resource_h)
     if resource_h['submission_id'].present?
       assignment = Assignment.find_by(submission_id: resource_h['submission_id'])
-      assignment&.receive_answer! sender: resource_h['message']['sender'],
+      assignment&.receive_answer! sender: User.locate!(resource_h['message']['sender']),
                                   content: resource_h['message']['content']
     end
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -17,7 +17,7 @@ class Message < ApplicationRecord
   markdown_on :content
 
   # Visible messages are those that can be publicly seen
-  # in forums. non-direct messages are never visible.
+  # in forums. Direct messages are never visible.
   scope :visible, -> () do
     where.not(deletion_motive: :self_deleted)
       .or(where(deletion_motive: nil))

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -135,6 +135,10 @@ class Message < ApplicationRecord
     'message'
   end
 
+  def sender
+    super || User.locate!(self[:sender])
+  end
+
   private
 
   def approve!(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,8 @@ class User < ApplicationRecord
   has_many :assignments, foreign_key: :submitter_id
   has_many :indicators
   has_many :user_stats, class_name: 'UserStats'
-  has_many :messages, -> { order(created_at: :desc) }, through: :assignments
+  has_many :forum_messages, -> { where.not(discussion_id: nil)  }, class_name: 'Message', foreign_key: :sender_id
+  has_many :direct_messages, -> { order(created_at: :desc) }, class_name: 'Message', source: :messages, through: :assignments
 
   has_many :submitted_exercises, through: :assignments, class_name: 'Exercise', source: :exercise
 
@@ -61,7 +62,7 @@ class User < ApplicationRecord
   end
 
   def messages_in_organization(organization = Organization.current)
-    messages.where('assignments.organization': organization)
+    direct_messages.where('assignments.organization': organization)
   end
 
   def passed_submissions_count_in(organization)
@@ -321,7 +322,7 @@ class User < ApplicationRecord
 
     target_assignments = assignments.where(location)
 
-    messages.where(assignment: target_assignments).delete_all
+    direct_messages.where(assignment: target_assignments).delete_all
 
     target_assignments.delete_all
     indicators.where(location).delete_all

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,6 @@ class User < ApplicationRecord
   has_many :assignments, foreign_key: :submitter_id
   has_many :indicators
   has_many :user_stats, class_name: 'UserStats'
-  has_many :forum_messages, -> { where.not(discussion_id: nil)  }, class_name: 'Message', foreign_key: :sender_id
   has_many :direct_messages, -> { order(created_at: :desc) }, class_name: 'Message', source: :messages, through: :assignments
 
   has_many :submitted_exercises, through: :assignments, class_name: 'Exercise', source: :exercise
@@ -335,6 +334,10 @@ class User < ApplicationRecord
 
   def ignores_notification?(notification)
     ignored_notifications.include? notification.subject
+  end
+
+  def forum_messages
+    Message.where(sender: self).or(Message.where('sender = ?', uid)).where.not(discussion_id: nil)
   end
 
   private

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -32,7 +32,7 @@ class UserStats < ApplicationRecord
 
   def messages_in_discussions_count(date_range = nil)
     date_filter = { created_at: date_range }.compact
-    result = user.messages.joins(:discussion)
+    result = user.forum_messages.joins(:discussion)
         .where({deletion_motive: nil, discussions: { organization: organization }}.merge(date_filter))
         .group(:approved)
         .count

--- a/app/models/user_stats.rb
+++ b/app/models/user_stats.rb
@@ -32,8 +32,8 @@ class UserStats < ApplicationRecord
 
   def messages_in_discussions_count(date_range = nil)
     date_filter = { created_at: date_range }.compact
-    result = Message.joins(:discussion)
-        .where({sender: user.uid, deletion_motive: nil, discussions: { organization: organization }}.merge(date_filter))
+    result = user.messages.joins(:discussion)
+        .where({deletion_motive: nil, discussions: { organization: organization }}.merge(date_filter))
         .group(:approved)
         .count
     unapproved = result[false] || 0

--- a/db/migrate/20211004062332_reference_sender_via_id_in_messages.rb
+++ b/db/migrate/20211004062332_reference_sender_via_id_in_messages.rb
@@ -1,0 +1,5 @@
+class ReferenceSenderViaIdInMessages < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :messages, :sender, index: true
+  end
+end

--- a/lib/mumuki/domain/factories/message_factory.rb
+++ b/lib/mumuki/domain/factories/message_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :message do
     content { Faker::Lorem.sentence(word_count: 3) }
-    sender { create(:user).uid }
+    sender { create(:user) }
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -373,7 +373,6 @@ ActiveRecord::Schema.define(version: 20211020224011) do
   create_table "messages", id: :serial, force: :cascade do |t|
     t.string "submission_id"
     t.text "content"
-    t.string "sender"
     t.datetime "date"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -387,10 +386,13 @@ ActiveRecord::Schema.define(version: 20211020224011) do
     t.datetime "deleted_at"
     t.bigint "deleted_by_id"
     t.bigint "assignment_id"
+    t.string "sender"
+    t.bigint "sender_id"
     t.boolean "from_moderator"
     t.index ["approved_by_id"], name: "index_messages_on_approved_by_id"
     t.index ["assignment_id"], name: "index_messages_on_assignment_id"
     t.index ["deleted_by_id"], name: "index_messages_on_deleted_by_id"
+    t.index ["sender_id"], name: "index_messages_on_sender_id"
   end
 
   create_table "notifications", force: :cascade do |t|

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -19,7 +19,7 @@ describe Assignment, organization_workspace: :test do
 
       it { expect(assignment.new_record?).to be false }
       it { expect(assignment.has_messages?).to be true }
-      it { expect(message.sender).to eq student.uid }
+      it { expect(message.sender).to eq student }
       it { expect(message.content).to eq 'How can i solve this?' }
       it { expect(message.read).to be true }
       it { expect(message.assignment).to eq assignment }
@@ -30,11 +30,11 @@ describe Assignment, organization_workspace: :test do
 
     describe '#receive_answer!' do
       before { problem.submit_question! student, content: 'How can i solve this?' }
-      before { assignment.receive_answer! sender: bot.uid, content: 'Check this link' }
+      before { assignment.receive_answer! sender: bot, content: 'Check this link' }
 
       it { expect(assignment.has_messages?).to be true }
       it { expect(assignment.messages.count).to eq 2 }
-      it { expect(message.sender).to eq 'bot@mumuki.org' }
+      it { expect(message.sender).to eq bot }
       it { expect(message.content).to eq 'Check this link' }
       it { expect(message.read).to be false }
       it { expect(message.assignment).to eq assignment }

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -288,7 +288,7 @@ describe Discussion, organization_workspace: :test do
 
       context 'when moderator comments' do
         before do
-          discussions.each { |it| create(:message, content: 'Help incoming', discussion: it, sender: moderator.uid) }
+          discussions.each { |it| create(:message, content: 'Help incoming', discussion: it, sender: moderator) }
         end
 
         it { expect(discussion_pending_review.requires_attention?).to be true }
@@ -299,7 +299,7 @@ describe Discussion, organization_workspace: :test do
 
         context 'when discussion initiator asks again' do
           before do
-            discussions.each { |it| create(:message, content: 'Sorry what?', discussion: it, sender: user.uid) }
+            discussions.each { |it| create(:message, content: 'Sorry what?', discussion: it, sender: user) }
           end
 
           it { expect(discussion_pending_review.requires_attention?).to be true }
@@ -312,7 +312,7 @@ describe Discussion, organization_workspace: :test do
         context 'when discussion initiator comments again but it is not a question' do
           before do
             discussions.each { |it| create(:message, content: 'Alright thanks', discussion: it,
-                                           sender: user.uid, not_actually_a_question: true) }
+                                           sender: user, not_actually_a_question: true) }
           end
 
           it { expect(discussion_pending_review.requires_attention?).to be true }
@@ -325,7 +325,7 @@ describe Discussion, organization_workspace: :test do
 
       context 'when a user comments and it\'s approved by a moderator' do
         before do
-          discussions.each { |it| create(:message, content: 'Here is some help', discussion: it, sender: create(:user).uid,
+          discussions.each { |it| create(:message, content: 'Here is some help', discussion: it, sender: create(:user),
                                          approved: true, approved_at: Time.now, approved_by: moderator) }
         end
 

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,10 +1,11 @@
 require 'spec_helper'
 
 describe Message, organization_workspace: :test do
+  let(:sender) { create :user, uid: 'sender@mumuki.org' }
 
   describe 'validations' do
     context 'when no context' do
-      let(:message) { Message.new content: 'content', sender: 'sender@mumuki.org' }
+      let(:message) { Message.new content: 'content', sender: sender }
       it { expect(message.contextualized?).to be false }
       it { expect(message.valid?).to be false }
     end
@@ -12,7 +13,7 @@ describe Message, organization_workspace: :test do
     context 'when improperly contextualized' do
       let(:message) do
         Message.new content: 'content',
-                    sender: 'sender@mumuki.org',
+                    sender: sender,
                     discussion: create(:discussion),
                     assignment: create(:assignment)
       end
@@ -24,7 +25,7 @@ describe Message, organization_workspace: :test do
     context 'when direct' do
       let(:message) do
         Message.new content: 'content',
-                    sender: 'sender@mumuki.org',
+                    sender: sender,
                     assignment: create(:assignment)
       end
 
@@ -35,7 +36,7 @@ describe Message, organization_workspace: :test do
     context 'when non-direct' do
       let(:message) do
         Message.new content: 'content',
-                    sender: 'sender@mumuki.org',
+                    sender: sender,
                     discussion: create(:discussion)
       end
       it { expect(message.contextualized?).to be true }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -757,11 +757,11 @@ describe User, organization_workspace: :test do
     before do
       organization_1.switch!
       assignment_1 = exercise_1.submit_solution!(user).tap(&:passed!)
-      create :message, sender: user.uid, assignment: assignment_1
+      create :message, sender: user, assignment: assignment_1
       organization_2.switch!
       assignment_2 = exercise_2.submit_solution!(user).tap(&:passed!)
-      create :message, sender: user.uid, assignment: assignment_2
-      create :message, sender: user.uid, discussion_id: 1
+      create :message, sender: user, assignment: assignment_2
+      create :message, sender: user, discussion_id: 1
     end
 
     it { expect(user.assignments.count).to eq 2 }


### PR DESCRIPTION
## :dart: Goal
Stop referencing user via uid in messages.

## :memo: Details
We resolved splitting migration into 2 stages:
We'll do a schema migration only adding the new sender_id column, and do data migration live, and we'll do a second schema migration removing the sender column at a later version. 

This needs to be run between both migrations:

```ruby
Message.distinct.pluck(:sender).each do |sender|
  Message.where('sender = ?', sender).update_all sender_id: User.locate!(sender).id rescue nil
end
```
## :warning: Dependencies
None.

## :back: Backwards compatibility
This requires some updates on dependent gems too.

## :soon: Future work
None.
