### PR TITLE
Feature delete user

### DIFF
--- a/app/models/concerns/with_deleted_user.rb
+++ b/app/models/concerns/with_deleted_user.rb
@@ -1,0 +1,29 @@
+module WithDeletedUser
+  def self.prepended(base)
+    super
+    base.before_destroy :forbid_destroy!, if: :deleted_user?
+    base.extend ClassMethods
+  end
+
+  def deleted_user?
+    self == User.deleted_user
+  end
+
+  def abbreviated_name
+    return super unless deleted_user?
+
+    I18n.t(:deleted_user, locale: (Organization.current.locale rescue 'en'))
+  end
+
+  module ClassMethods
+    def deleted_user
+      @deleted_user ||= User.create_with(@buried_profile).find_or_create_by(uid: 'deleted:shibi')
+    end
+  end
+
+  private
+
+  def forbid_destroy!
+    raise '"Deleted User" shibi cannot be destroyed'
+  end
+end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -142,7 +142,7 @@ class Discussion < ApplicationRecord
   end
 
   def responses_count
-    visible_messages.where('sender <> ? OR sender_id <> ?', initiator.uid, initiator.id).count
+    visible_messages.where.not(sender: initiator).count
   end
 
   def has_responses?

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -135,10 +135,6 @@ class Message < ApplicationRecord
     'message'
   end
 
-  def sender
-    super || User.locate!(self[:sender])
-  end
-
   private
 
   def approve!(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ApplicationRecord
   has_many :assignments, foreign_key: :submitter_id
   has_many :indicators
   has_many :user_stats, class_name: 'UserStats'
+  has_many :forum_messages, -> { where.not(discussion_id: nil)  }, class_name: 'Message', foreign_key: :sender_id
   has_many :direct_messages, -> { order(created_at: :desc) }, class_name: 'Message', source: :messages, through: :assignments
 
   has_many :submitted_exercises, through: :assignments, class_name: 'Exercise', source: :exercise
@@ -339,10 +340,6 @@ class User < ApplicationRecord
 
   def ignores_notification?(notification)
     ignored_notifications.include? notification.subject
-  end
-
-  def forum_messages
-    Message.where(sender: self).or(Message.where('sender = ?', uid)).where.not(discussion_id: nil)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ApplicationRecord
           Onomastic,
           Mumuki::Domain::Helpers::User
 
+  prepend WithDeletedUser
+
   serialize :permissions, Mumukit::Auth::Permissions
   serialize :ignored_notifications, Array
 
@@ -344,10 +346,6 @@ class User < ApplicationRecord
     ignored_notifications.include? notification.subject
   end
 
-  def self.deleted_user
-    @deleted_user ||= create_with(@buried_profile).find_or_create_by(uid: 'deleted:shibi')
-  end
-
   def clean_belongings!
     discussions.update_all initiator_id: User.deleted_user.id
     forum_messages.update_all sender_id: User.deleted_user.id
@@ -402,19 +400,5 @@ class User < ApplicationRecord
 
   def self.buried_profile
     (@buried_profile || {}).slice(:first_name, :last_name, :email)
-  end
-end
-
-class << User.deleted_user
-  before_destroy :forbid_destroy!
-
-  def abbreviated_name
-    I18n.t(:deleted_user, locale: (Organization.current.locale rescue 'en'))
-  end
-
-  private
-
-  def forbid_destroy!
-    raise '"Deleted User" shibi cannot be destroyed'
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -340,6 +340,10 @@ class User < ApplicationRecord
     ignored_notifications.include? notification.subject
   end
 
+  def self.deleted_user
+    @deleted_user ||= create_with(@buried_profile).find_or_create_by(uid: 'deleted:shibi')
+  end
+
   private
 
   def welcome_to_new_organizations!
@@ -388,5 +392,19 @@ class User < ApplicationRecord
 
   def self.buried_profile
     (@buried_profile || {}).slice(:first_name, :last_name, :email)
+  end
+end
+
+class << User.deleted_user
+  before_destroy :forbid_destroy!
+
+  def abbreviated_name
+    I18n.t(:deleted_user, locale: (Organization.current.locale rescue 'en'))
+  end
+
+  private
+
+  def forbid_destroy!
+    raise '"Deleted User" shibi cannot be destroyed'
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,6 @@ class User < ApplicationRecord
           WithNotifications,
           WithDiscussionCreation,
           Awardee,
-          Disabling,
           WithTermsAcceptance,
           WithPreferences,
           Onomastic,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,12 +14,20 @@ class User < ApplicationRecord
   serialize :permissions, Mumukit::Auth::Permissions
   serialize :ignored_notifications, Array
 
-  has_many :notifications
-  has_many :assignments, foreign_key: :submitter_id
-  has_many :indicators
-  has_many :user_stats, class_name: 'UserStats'
+  before_destroy :clean_belongings!
+
+  has_many :api_clients,                             dependent: :delete_all
+  has_many :assignments, foreign_key: :submitter_id, dependent: :delete_all
+  has_many :certificates,                            dependent: :delete_all
+  has_many :exam_authorizations,                     dependent: :delete_all
+  has_many :exam_authorization_requests,             dependent: :delete_all
+  has_many :notifications,                           dependent: :delete_all
+  has_many :indicators,                              dependent: :delete_all
+  has_many :user_stats, class_name: 'UserStats',     dependent: :delete_all
+
+  has_many :discussions, foreign_key: :initiator_id
   has_many :forum_messages, -> { where.not(discussion_id: nil)  }, class_name: 'Message', foreign_key: :sender_id
-  has_many :direct_messages, -> { order(created_at: :desc) }, class_name: 'Message', source: :messages, through: :assignments
+  has_many :direct_messages, -> { order(created_at: :desc) }, through: :assignments, source: :messages
 
   has_many :submitted_exercises, through: :assignments, class_name: 'Exercise', source: :exercise
 
@@ -34,11 +42,7 @@ class User < ApplicationRecord
 
   has_one :last_guide, through: :last_exercise, source: :guide
 
-  has_many :exam_authorizations
-
   has_many :exams, through: :exam_authorizations
-
-  has_many :certificates
 
   enum gender: %i(female male other unspecified)
   belongs_to :avatar, polymorphic: true, optional: true
@@ -342,6 +346,12 @@ class User < ApplicationRecord
 
   def self.deleted_user
     @deleted_user ||= create_with(@buried_profile).find_or_create_by(uid: 'deleted:shibi')
+  end
+
+  def clean_belongings!
+    discussions.update_all initiator_id: User.deleted_user.id
+    forum_messages.update_all sender_id: User.deleted_user.id
+    direct_messages.where(sender: self).delete_all
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -156,7 +156,6 @@ class User < ApplicationRecord
     update! accepts_reminders: false
   end
 
-
   def attach!(role, course)
     add_permission! role, course.slug
     save_and_notify!
@@ -374,10 +373,6 @@ class User < ApplicationRecord
 
   def self.sync_key_id_field
     :uid
-  end
-
-  def self.unsubscription_verifier
-    Rails.application.message_verifier(:unsubscribe)
   end
 
   def self.create_if_necessary(user)

--- a/db/migrate/20211104182009_remove_sender_uid_from_messages.rb
+++ b/db/migrate/20211104182009_remove_sender_uid_from_messages.rb
@@ -1,0 +1,5 @@
+class RemoveSenderUidFromMessages < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :messages, :sender, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20211020224011) do
+ActiveRecord::Schema.define(version: 20211104182009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -386,7 +386,6 @@ ActiveRecord::Schema.define(version: 20211020224011) do
     t.datetime "deleted_at"
     t.bigint "deleted_by_id"
     t.bigint "assignment_id"
-    t.string "sender"
     t.bigint "sender_id"
     t.boolean "from_moderator"
     t.index ["approved_by_id"], name: "index_messages_on_approved_by_id"


### PR DESCRIPTION
## :dart: Goal
Allow properly deleting users.

## :memo: Details
`direct_messages` association gave me some trouble:
- since it's a transitive association it can not be deleted through a `dependent: :delete_all`
- I tried changing it to a direct association through `sender_id`, but this caused problems as the original `messages` includes not only sent messages, but received ones too.
- I ended up transfering them to deleted user too instead of deleting them just on the off chance that they could be of use once we redo classroom.

Apparently the rails version we're using right now's `ActiveSupport::Concern` does not include prepended helpers yet, so I had to define `WithDeletedUser` with the more traditional syntax.

## :warning: Dependencies
None.

## :back: Backwards compatibility
Requires updates on apps too.

## :soon: Future work
Fix tests.
