### PR TITLE
Feature time left for exam

### DIFF
--- a/app/models/exam.rb
+++ b/app/models/exam.rb
@@ -96,6 +96,10 @@ class Exam < ApplicationRecord
     end
   end
 
+  def time_left(user)
+    (real_end_time(user) - Time.current).round
+  end
+
   def started_at(user)
     authorization_for(user).started_at
   end

--- a/spec/models/exam_spec.rb
+++ b/spec/models/exam_spec.rb
@@ -162,6 +162,25 @@ describe Exam, organization_workspace: :test do
     end
   end
 
+  describe '#time_left' do
+    let(:user) { create(:user) }
+    let(:exam) { create :exam }
+
+    before { allow(Time).to receive(:current).and_return(current_time) }
+
+    context 'with time left' do
+      let(:current_time) { exam.real_end_time(user) - 10.minutes }
+
+      it { expect(exam.time_left user).to eq(600) }
+    end
+
+    context 'with no time left' do
+      let(:current_time) { exam.real_end_time(user) + 10.minutes }
+
+      it { expect(exam.time_left user).to eq(-600) }
+    end
+  end
+
   describe 'update exam does not change user started_at' do
     let(:user) { create(:user, uid: 'auth0|1') }
     let(:guide) { create(:guide) }


### PR DESCRIPTION
## :dart: Goal
Add method that responds how many seconds are left on exam for user to use in Laboratory.

## :memo: Details
None.

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
None.
