### PR TITLE
Fix in preparation mode for ex students work like organization disabled

### DIFF
--- a/app/models/concerns/organization/status/in_preparation.rb
+++ b/app/models/concerns/organization/status/in_preparation.rb
@@ -9,7 +9,7 @@ class Organization::Status::InPreparation < Organization::Status::Base
   end
 
   def ex_student_access_mode(user)
-    OrganizationAccessMode::Forbidden.new user, organization
+    OrganizationAccessMode::ReadOnly.new user, organization, :faqs, :profile
   end
 
   def outsider_access_mode(user)

--- a/app/models/organization_access_mode/read_only.rb
+++ b/app/models/organization_access_mode/read_only.rb
@@ -17,7 +17,7 @@ class OrganizationAccessMode::ReadOnly < OrganizationAccessMode::Base
   end
 
   def validate_discuss_here!(discussion)
-    super(discussion) unless discussion&.initiator == user
+    super(discussion) unless discuss_here? && discussion&.initiator == user
   end
 
   def show_content?(content)

--- a/spec/models/organization_status_spec.rb
+++ b/spec/models/organization_status_spec.rb
@@ -173,9 +173,9 @@ describe WithOrganizationStatus do
         context 'and user is ex student of organization' do
           before { user.update! permissions: { ex_student: slug } }
 
-          it { expect(access_mode).to be_an_instance_of OrganizationAccessMode::Forbidden }
-          it { expect(access_mode.faqs_here?).to be false }
-          it { expect(access_mode.profile_here?).to be false }
+          it { expect(access_mode).to be_an_instance_of OrganizationAccessMode::ReadOnly }
+          it { expect(access_mode.faqs_here?).to be true }
+          it { expect(access_mode.profile_here?).to be true }
           it { expect(access_mode.discuss_here?).to be false }
           it { expect(access_mode.submit_solutions_here?).to be false }
           it { expect(access_mode.resolve_discussions_here?).to be false }
@@ -183,10 +183,10 @@ describe WithOrganizationStatus do
           it { expect(access_mode.show_content? exercise2).to be false }
           it { expect(access_mode.show_discussion_element?).to be false }
           it { expect(access_mode.show_content_element?).to be false }
-          it { expect { access_mode.validate_active! }.to raise_error Mumuki::Domain::ForbiddenError }
+          it { expect { access_mode.validate_active! }.not_to raise_error }
+          it { expect { access_mode.validate_discuss_here! discussion }.to raise_error Mumuki::Domain::ForbiddenError }
           it { expect { access_mode.validate_content_here! exercise1 }.to raise_error Mumuki::Domain::ForbiddenError }
           it { expect { access_mode.validate_content_here! exercise2 }.to raise_error Mumuki::Domain::ForbiddenError }
-          it { expect { access_mode.validate_discuss_here! discussion }.to raise_error Mumuki::Domain::ForbiddenError }
         end
 
         context 'and user is outsider of organization' do
@@ -265,7 +265,7 @@ describe WithOrganizationStatus do
           it { expect { access_mode.validate_active! }.not_to raise_error }
           it { expect { access_mode.validate_content_here! exercise1 }.to raise_error Mumuki::Domain::ForbiddenError }
           it { expect { access_mode.validate_content_here! exercise2 }.to raise_error Mumuki::Domain::ForbiddenError }
-          it { expect { access_mode.validate_discuss_here! discussion }.not_to raise_error }
+          it { expect { access_mode.validate_discuss_here! discussion }.to raise_error Mumuki::Domain::ForbiddenError }
         end
 
         context 'and user is outsider of organization' do


### PR DESCRIPTION
## :dart: Goal
@NadiaFinzi here is the fix for the behavior that you expect for ex students when organization is in preparation

## :memo: Details
Behavior for ex students is the same for in preparation and disabled organization status.
They only have access to profile and faqs.

## :back: Backwards compatibility
100%

