### PR TITLE
Add email validator dependency

### DIFF
--- a/lib/mumuki/domain.rb
+++ b/lib/mumuki/domain.rb
@@ -1,4 +1,5 @@
-require "mumuki/domain/engine"
+require 'email_validator/strict'
+require 'mumuki/domain/engine'
 
 require 'mumukit/core'
 require 'mumukit/core/activemodel'

--- a/mumuki-domain.gemspec
+++ b/mumuki-domain.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 5.1.6"
 
+  s.add_dependency  'email_validator', '~> 1.6'
+
   s.add_dependency 'mumukit-auth', '~> 7.11'
   s.add_dependency 'mumukit-assistant', '~> 0.2'
   s.add_dependency 'mumukit-bridge', '~> 4.1'
@@ -34,4 +36,3 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pg', '~> 0.18.0'
   s.add_development_dependency 'bundler', '~> 2.0'
 end
-

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -308,11 +308,11 @@ describe Assignment, organization_workspace: :test do
   end
 
   describe '#extra' do
-    let(:user) { create(:user, email: 'some_email', first_name: 'some_first_name', last_name: 'some_last_name') }
+    let(:user) { create(:user, email: 'some_email@foo.com', first_name: 'some_first_name', last_name: 'some_last_name') }
     let(:exercise) { create(:exercise, extra: "/*...user_email...*/\n/*...user_first_name...*/\n/*...user_last_name...*/") }
     let(:assignment) { exercise.submit_solution!(user, content: '') }
 
-    it { expect(assignment.extra).to eq "some_email\nsome_first_name\nsome_last_name\n" }
+    it { expect(assignment.extra).to eq "some_email@foo.com\nsome_first_name\nsome_last_name\n" }
   end
 
   describe '#affable_expectation_results' do


### PR DESCRIPTION
## :dart: Goal

~To make some student identifying data more consistent.~ 
To allow classroom to validate student identifying data. 

## :memo: Details

~Email is guaranteed to be valid as long as it is non-empty.  Also, first_name is always validated on update.~
~:warning: I am not sure if there could be any issue with social accounts when they don't provide an email and then you try to set it on first login. Will it work? @felipecalvo~ 


I have just added a dependency on `email_validator` The rest will be done here https://github.com/mumuki/mumuki-classroom-api/pull/242

## :back: Backwards compatibility

This PR is backwards compatible. 

