### PR TITLE
Chore tidy up discussion methods

### DIFF
--- a/app/models/concerns/with_discussion_status.rb
+++ b/app/models/concerns/with_discussion_status.rb
@@ -4,7 +4,6 @@ module WithDiscussionStatus
   included do
     serialize :status, Mumuki::Domain::Status::Discussion
     validates_presence_of :status
-    scope :by_status, -> (status) { where(status: status) }
   end
 
   delegate :closed?, :opened?, :solved?, :pending_review?, :reachable_statuses, to: :status

--- a/lib/mumuki/domain/status.rb
+++ b/lib/mumuki/domain/status.rb
@@ -25,6 +25,14 @@ module Mumuki::Domain::Status
     self.equal? parent.to_mumuki_status(other) rescue false
   end
 
+  def as_json(_options={})
+    to_s
+  end
+
+  def dup
+    self
+  end
+
   class_methods do
     def load(i)
       cast(i)

--- a/lib/mumuki/domain/status/discussion/discussion.rb
+++ b/lib/mumuki/domain/status/discussion/discussion.rb
@@ -33,8 +33,4 @@ module Mumuki::Domain::Status::Discussion
       reachable_statuses_for_initiator(discussion)
     end
   end
-
-  def as_json(_options={})
-    to_s
-  end
 end

--- a/lib/mumuki/domain/status/submission/submission.rb
+++ b/lib/mumuki/domain/status/submission/submission.rb
@@ -31,10 +31,6 @@ module Mumuki::Domain::Status::Submission
     group.iconize
   end
 
-  def as_json(_options={})
-    to_s
-  end
-
   def completed?
     solved?
   end
@@ -49,9 +45,5 @@ module Mumuki::Domain::Status::Submission
 
   def exp_given
     0
-  end
-
-  def dup
-    self
   end
 end


### PR DESCRIPTION
## :dart: Goal
Tidy up some discussion methods.

## :memo: Details
Since status objects are singletons, asking for a dup should return the same object. Moving that logic to status mixin to fix trouble duping discussions.

## :warning: Dependencies
Yes.

## :back: Backwards compatibility
Should be merged together with https://github.com/mumuki/mumuki-laboratory/pull/1715.

## :soon: Future work
None.
